### PR TITLE
Code to enable deployment to a remote development environment on AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ site_media/
 static/dist/
 .DS_Store
 .vscode
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM circleci/python:3.7-rc-node
+USER root
+RUN mkdir -p /srv/code
+WORKDIR /srv/code
+#Copy code from current directory to /srv/code/ in image
+ADD . .
+RUN apt-get install nginx
+# Install Python dependencies
+RUN pipenv install --system --deploy
+#Install static dependencies
+RUN npm i
+EXPOSE 8001 80
+COPY ./docker-entrypoint.sh /
+COPY ./hedera_nginx.conf /etc/nginx/sites-available/
+RUN ln -s /etc/nginx/sites-available/hedera_nginx.conf /etc/nginx/sites-enabled
+RUN echo "daemon off;" >> /etc/nginx/nginx.conf
+
+RUN npm rebuild node-sass
+RUN npm run build
+
+RUN python manage.py migrate
+RUN python manage.py loaddata sites
+RUN python manage.py collectstatic --noinput
+
+ENTRYPOINT ["sh", "/docker-entrypoint.sh"]

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pinax-eventlog = "*"
 django = "*"
 django-webpack-loader = "*"
 pinax-templates = "*"
+gunicorn = "*"
 
 [dev-packages]
 "flake8" = "<3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "69f9ed78f1f1549195ca85dfd661ebe5cde1704138d8c565daf8037328797205"
+            "sha256": "4ab2c1f9070165c85d6a8a6b388565f687f069b0069dc88d08e4df539f533b4e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "django": {
             "hashes": [
-                "sha256:acdcc1f61fdb0a0c82a1d3bf1879a414e7732ea894a7632af7f6d66ec7ab5bb3",
-                "sha256:efbcad7ebb47daafbcead109b38a5bd519a3c3cd92c6ed0f691ff97fcdd16b45"
+                "sha256:1ffab268ada3d5684c05ba7ce776eaeedef360712358d6a6b340ae9f16486916",
+                "sha256:dd46d87af4c1bf54f4c926c3cfa41dc2b5c15782f15e4329752ce65f5dad1c37"
             ],
             "index": "pypi",
-            "version": "==2.1.2"
+            "version": "==2.1.3"
         },
         "django-appconf": {
             "hashes": [
@@ -53,6 +53,14 @@
             "index": "pypi",
             "version": "==0.6.0"
         },
+        "gunicorn": {
+            "hashes": [
+                "sha256:aa8e0b40b4157b36a5df5e599f45c9c76d6af43845ba3b3b0efe2c70473c2471",
+                "sha256:fa2662097c66f920f53f70621c6c58ca4a3c4d3434205e608e121b5b3b71f4f3"
+            ],
+            "index": "pypi",
+            "version": "==19.9.0"
+        },
         "jsonfield": {
             "hashes": [
                 "sha256:a0a7fdee736ff049059409752b045281a225610fecbda9b9bd588ba976493c12",
@@ -78,10 +86,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:642253af8eae734d1509fc6ac9c1aee5e5b69d76392660889979b9870610a46b",
-                "sha256:91e3ccf2c344ffaa6defba1ce7f38f97026943f675b7703f44789768e4cb0ece"
+                "sha256:31cb35c89bd7d333cd32c5f278fca91b523b0834369e757f4c5641ea252236ca",
+                "sha256:8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6"
             ],
-            "version": "==2018.6"
+            "version": "==2018.7"
         }
     },
     "develop": {

--- a/basic/settings.py
+++ b/basic/settings.py
@@ -15,7 +15,9 @@ DATABASES = {
 }
 
 ALLOWED_HOSTS = [
-    "localhost",
+    'localhost',
+    '127.0.0.1',
+    'atg-dev-hedera-lb-2073615562.us-east-1.elb.amazonaws.com'
 ]
 
 # Local time zone for this installation. Choices can be found here:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - $(aws ecr get-login --region us-east-1 --no-include-email)
+      - REPOSITORY_URI=304068128243.dkr.ecr.us-east-1.amazonaws.com/hedera-dev
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...          
+      - docker build -t $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - printf '[{"name":"hedera-dev","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+artifacts:
+    files: imagedefinitions.json

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+gunicorn basic.wsgi:application --bind 127.0.0.1:8001 --daemon
+service nginx start

--- a/hedera_nginx.conf
+++ b/hedera_nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name ~^(.+)$;
+
+    # location of static files
+    location /site_media/static/ {
+        autoindex on;
+        root /srv/code/basic;
+    }
+
+    # location of app
+    location / {
+        include proxy_params;
+        proxy_pass http://127.0.0.1:8001;
+    }
+}
+


### PR DESCRIPTION
This PR introduces the following changes that enable a deployment to a development environment on AWS:

- A ./Dockerfile containing instructions to build the application and bundle it in a docker image
- A ./buildspec.yml file that triggers the aforementioned Dockerfile instructions
- A ./hedera_nginx.conf that configures nginx for the app
- A ./docker-entrypoint.sh file that runs nginx and gunicorn so that the application can be served up

An infrastructure setup of this project is to be found at https://github.com/Hedera-Lang-Learn/hedera-terraform/tree/aws-codepipeline-ecs-IaC. Thus, a quick way to test the changes introduced in this PR would be to run the `terraform [command]` commands in the aforementioned repo. That repo contains a CodeBuild and CodePipeline that will engage all the PR changes in this PR. Expressed elaborately, the terraform code in the aforementioned repo depends on a proper setup of the ./Dockerfile, ./buildspec.yml, ./hedera_nginx.conf, and ./docker-entrypoint.sh files in this repo. Hence, it might be effective to test the terraform code first, before diving head-first in the PR changes in this repo - just for the sake of catching errors quickly, at least. Please let me know if you have any questions.