### PR TITLE
Use dj_database_url for db backend config

### DIFF
--- a/docker-entrypoint-dev.sh
+++ b/docker-entrypoint-dev.sh
@@ -2,6 +2,7 @@
 
 export AWS_SECRET_ACCESS_KEY=`aws ssm get-parameter --name /hedera/dev/aws_secret_access_key --with-decryption --output text --query Parameter.Value --region us-east-1`
 export AWS_ACCESS_KEY_ID=`aws ssm get-parameter --name /hedera/dev/aws_access_key_id --with-decryption --output text --query Parameter.Value --region us-east-1`
+export DATABASE_URL=`aws ssm get-parameter --name /hedera/dev/dj_database_url --with-decryption --output text --query Parameter.Value --region us-east-1`
 export DB_HOST=`aws ssm get-parameter --name /hedera/dev/db_host --output text --query Parameter.Value --region us-east-1`
 export DB_NAME=`aws ssm get-parameter --name /hedera/dev/db_name --output text --query Parameter.Value --region us-east-1`
 export DB_PASSWORD=`aws ssm get-parameter --name /hedera/dev/db_password --with-decryption --output text --query Parameter.Value --region us-east-1`
@@ -25,11 +26,7 @@ python manage.py collectstatic --noinput
 sudo gunicorn hedera.wsgi:application \
     --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-    --env DB_HOST=$DB_HOST \
-    --env DB_NAME=$DB_NAME \
-    --env DB_PASSWORD=$DB_PASSWORD \
-    --env DB_PORT=$DB_PORT \
-    --env DB_USER=$DB_USER \
+    --env DATABASE_URL=$DATABASE_URL \
     --env DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY \
     --env AWS_STORAGE_BUCKET_NAME=$AWS_STORAGE_BUCKET_NAME \
     --env USE_S3=True \

--- a/docker-entrypoint-prod.sh
+++ b/docker-entrypoint-prod.sh
@@ -2,6 +2,7 @@
 
 export AWS_SECRET_ACCESS_KEY=`aws ssm get-parameter --name /hedera/prod/aws_secret_access_key --with-decryption --output text --query Parameter.Value --region us-east-1`
 export AWS_ACCESS_KEY_ID=`aws ssm get-parameter --name /hedera/prod/aws_access_key_id --with-decryption --output text --query Parameter.Value --region us-east-1`
+export DATABASE_URL=`aws ssm get-parameter --name /hedera/prod/dj_database_url --with-decryption --output text --query Parameter.Value --region us-east-1`
 export DB_HOST=`aws ssm get-parameter --name /hedera/prod/db_host --output text --query Parameter.Value --region us-east-1`
 export DB_NAME=`aws ssm get-parameter --name /hedera/prod/db_name --output text --query Parameter.Value --region us-east-1`
 export DB_PASSWORD=`aws ssm get-parameter --name /hedera/prod/db_password --with-decryption --output text --query Parameter.Value --region us-east-1`
@@ -18,18 +19,14 @@ export EMAIL_USE_TLS=True
 export USE_S3=True
 export SITE_ID=4
 
-
+python manage.py makemigrations
 python manage.py migrate
 python manage.py collectstatic --noinput
 
 sudo gunicorn hedera.wsgi:application \
     --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
     --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-    --env DB_HOST=$DB_HOST \
-    --env DB_NAME=$DB_NAME \
-    --env DB_PASSWORD=$DB_PASSWORD \
-    --env DB_PORT=$DB_PORT \
-    --env DB_USER=$DB_USER \
+    --env DATABASE_URL=$DATABASE_URL \
     --env DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY \
     --env AWS_STORAGE_BUCKET_NAME=$AWS_STORAGE_BUCKET_NAME \
     --env USE_S3=True \


### PR DESCRIPTION
DATABASE_URL is used in place the canonical django database env variables, e.g. DB_NAME, DB_HOST, etc, for specifying a database backend.
See https://github.com/kennethreitz/dj-database-url for reference.