### PR TITLE
Add DEFAULT_FROM_EMAIL env var

### DIFF
--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -245,7 +245,7 @@ EMAIL_HOST = os.environ.get("EMAIL_HOST", "")
 EMAIL_PORT = os.environ.get("EMAIL_PORT", "")
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
-#DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_EMAIL_FROM", "")
+DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL", "")
 EMAIL_USE_TLS = True
 
 TEXT_PROVIDER_BACKENDS = [


### PR DESCRIPTION
Adding a DEFAULT_FROM_EMAIL directive in the settings module that specifies the default email sending address. This is to be populated by an environment variable of the same name.