### PR TITLE
Russian Lemmatizer

### DIFF
--- a/hedera/templates/lemmatized_text/create.html
+++ b/hedera/templates/lemmatized_text/create.html
@@ -21,6 +21,7 @@
       <select name="lang" class="form-control">
         <option value="grc" {% if cloned_from.lang == "grc" %}select{% endif %}>Greek</option>
         <option value="lat" {% if cloned_from.lang == "lat" %}select{% endif %}>Latin</option>
+        <option value="rus" {% if cloned_from.lang == "rus" %}select{% endif %}>Russian</option>
       </select>
     </div>
     {% if cloned_from %}

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -8,7 +8,7 @@ from .services import morpheus, clancydb
 
 SERVICES = {
     "lat": morpheus,
-    "grk": morpheus,
+    "grc": morpheus,
     "rus": clancydb,
 }
 

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -1,16 +1,26 @@
 from lattices.utils import get_lattice_node
 
 from .models import add_form, lookup_form
-from .morpheus import morpheus
+from .services import morpheus, clancydb
 
 
 # from vocab_list.models import VocabularyList
+
+SERVICES = {
+    "lat": morpheus,
+    "grk": morpheus,
+    "rus": clancydb,
+}
 
 
 def lemmatize_word(form, lang, force_refresh=False):
     s = lookup_form(form)
     if not s or force_refresh:
-        s |= add_form("morpheus", lang, form, morpheus(form, lang))
+        service = SERVICES.get(lang)
+        if service:
+            s |= add_form(service.SID, lang, form, service.lemmatize_word(form, lang))
+        else:
+            raise ValueError(f"Lemmatization not supported for language '{lang}''")
     return list(s)
 
 

--- a/lemmatization/services/clancydb.py
+++ b/lemmatization/services/clancydb.py
@@ -1,0 +1,41 @@
+from urllib.parse import urlencode
+
+import requests
+
+SID = "clancydb"
+
+def lemmatize_word(form, lang):
+    """
+    headword/lemma retrieval from Steven Clancy's russian database.
+
+    >>> lemmatize_word("газету", "rus")
+    ['газета']
+    >>> lemmatize_word("дела", "rus")
+    ['дело', 'деть']
+    >>> lemmatize_word("ру́сская", "rus")
+    ['русский']
+    >>> lemmatize_word("все", "rus")
+    ['весь', 'все', 'всё']
+    >>> lemmatize_word("мороженое", "rus")
+    ['мороженый', 'мороженое']
+    """
+    if lang != "rus":
+        raise ValueError("lang must be one of 'rus'")
+
+    params = {"word": form}
+    qs = urlencode(params)
+    url = f"http://visualizingrussian.fas.harvard.edu/api/lemmatize?{qs}"
+    headers = {
+        "Accept": "application/json",
+    }
+    r = requests.get(url, headers=headers)
+    if r.ok:
+        body = r.json().get("data", {}).get("lemmas", [])
+        if not isinstance(body, list):
+            body = [] 
+    else:
+        body = []
+
+    lemmas = [item["label"] for item in body]
+    return lemmas
+

--- a/lemmatization/services/clancydb.py
+++ b/lemmatization/services/clancydb.py
@@ -4,6 +4,8 @@ import requests
 
 SID = "clancydb"
 
+LANGUAGES = ("rus",)
+
 def lemmatize_word(form, lang):
     """
     headword/lemma retrieval from Steven Clancy's russian database.
@@ -19,8 +21,9 @@ def lemmatize_word(form, lang):
     >>> lemmatize_word("мороженое", "rus")
     ['мороженый', 'мороженое']
     """
-    if lang != "rus":
-        raise ValueError("lang must be one of 'rus'")
+
+    if lang not in LANGUAGES:
+        raise ValueError(f"lang must be one of {LANGUAGES}")
 
     params = {"word": form}
     qs = urlencode(params)

--- a/lemmatization/services/morpheus.py
+++ b/lemmatization/services/morpheus.py
@@ -4,6 +4,7 @@ import requests
 
 SID = "morpheus"
 
+LANGUAGES = ("grc", "lat")
 
 def lemmatize_word(form, lang):
     """
@@ -15,8 +16,8 @@ def lemmatize_word(form, lang):
     ['edo1', 'sum1']
     """
 
-    if lang not in ["grc", "lat"]:
-        raise ValueError("lang must be one of 'grc' or 'lat'")
+    if lang not in LANGUAGES:
+        raise ValueError(f"lang must be one of {LANGUAGES}")
 
     params = {
         "word": form,

--- a/lemmatization/services/morpheus.py
+++ b/lemmatization/services/morpheus.py
@@ -2,14 +2,16 @@ from urllib.parse import urlencode
 
 import requests
 
+SID = "morpheus"
 
-def morpheus(form, lang):
+
+def lemmatize_word(form, lang):
     """
     headword/lemma retrieval from the Perseids Morphology Service
 
-    >>> morpheus("λόγος", "grc")
+    >>> lemmatize_word("λόγος", "grc")
     ['λόγος']
-    >>> morpheus("est", "lat")
+    >>> lemmatize_word("est", "lat")
     ['edo1', 'sum1']
     """
 


### PR DESCRIPTION
First pass at updating `lemmatize_word()` to support russian word forms by calling out to a service that I've dubbed `clancydb` (named for Steven Clancy who created the database).

Since we'd like to be able to support other languages too, rather than hard-coding the method call,  I've created a mapping of each language code to a module capable of lemmatizing that language. The only requirement is that the module implements a `lemmatize_word(form, lang)` function and declares a service identifier (SID). 

This structure should make it possible to add other languages in a straightforward manner. A module could support one language like `clancydb` or multiple languages like `morpheus`.
