### PR TITLE
Run with console email backend by default to make local dev easy

### DIFF
--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -251,7 +251,7 @@ AUTHENTICATION_BACKENDS = [
 
 LOGIN_URL = "account_login"
 
-#EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
+EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "django.core.mail.backends.console.EmailBackend")
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "")
 EMAIL_PORT = os.environ.get("EMAIL_PORT", "")
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")


### PR DESCRIPTION
Not sure why this was commented out but this avoids real email from trying to be sent during local development.