### PR TITLE
Refactor services extracting tokenizations/stripping

### DIFF
--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -4,6 +4,7 @@ from .models import add_form, lookup_form
 from .services.clancydb import ClancyService
 from .services.morpheus import MorpheusService
 
+
 # from vocab_list.models import VocabularyList
 
 SERVICES = {

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -1,49 +1,63 @@
 from lattices.utils import get_lattice_node
 
 from .models import add_form, lookup_form
-from .services import clancydb, morpheus
-
+from .services.clancydb import ClancyService
+from .services.morpheus import MorpheusService
 
 # from vocab_list.models import VocabularyList
 
 SERVICES = {
-    "lat": morpheus,
-    "grc": morpheus,
-    "rus": clancydb,
+    "lat": MorpheusService(lang="lat"),
+    "grc": MorpheusService(lang="grc"),
+    "rus": ClancyService(lang="rus"),
 }
 
 
-def lemmatize_word(form, lang, force_refresh=False):
-    s = lookup_form(form)
-    if not s or force_refresh:
-        service = SERVICES.get(lang)
-        if service:
-            s |= add_form(service.SID, lang, form, service.lemmatize_word(form, lang))
-        else:
+class Lemmatizer(object):
+
+    def __init__(self, lang, cb=None, force_refresh=False):
+        self.lang = lang
+        self.cb = cb
+        self.force_refresh = force_refresh
+        self._service = SERVICES.get(lang)
+        if self._service is None:
             raise ValueError(f"Lemmatization not supported for language '{lang}''")
-    return list(s)
 
+    def _tokenize(self, text):
+        return self._service.tokenize(text)
 
-def lemmatize_text(text, lang, cb=None):
-    result = []
-    tokens = text.replace("—", "— ").split()
-    total_count = len(tokens)
-    for index, token in enumerate(tokens):
-        stripped_token = token.strip(",.?:;·—")
-        lemmas = lemmatize_word(stripped_token, lang)
-        node = get_lattice_node(lemmas, stripped_token)  # @@@ not sure what to use for context here
-        if not node or node.children.exists():
-            resolved = False
-        else:
-            resolved = True
-        if node:
-            node_pk = node.pk
-        else:
-            node_pk = None
-        result.append({"token": token, "node": node_pk, "resolved": resolved})
-        if callable(cb):
-            cb((index + 1) / total_count)
-    return result
+    def _strip(self, token):
+        return self._service.strip_token(token)
+
+    def _lemmatize_token(self, token):
+        s = lookup_form(token)
+        if not s or self.force_refresh:
+            lemmas = self._service.lemmatize(token)
+            s |= add_form(
+                context=self._service.SID,
+                lang=self.lang,
+                form=token,
+                lemmas=lemmas
+            )
+        return list(s)
+
+    def _report_progress(self, index, total_count):
+        if callable(self.cb):
+            self.cb((index + 1) / total_count)
+
+    def lemmatize(self, text):
+        result = []
+        tokens = self._tokenize(text)
+        total_count = len(tokens)
+        for index, token in enumerate(tokens):
+            stripped_token = self._strip(token)
+            lemmas = self._lemmatize_token(stripped_token)
+            node = get_lattice_node(lemmas, stripped_token)  # @@@ not sure what to use for context here
+            resolved = node and not node.children.exists()
+            node_pk = node.pk if node else None
+            result.append(dict(token=token, node=node_pk, resolved=resolved))
+            self._report_progress(index, total_count)
+        return result
 
 
 # gnt80 = VocabularyList.objects.get(pk=1)

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -1,0 +1,38 @@
+import requests
+
+
+class Service(object):
+
+    SID = None
+    LANGUAGES = []
+    ENDPOINT = ""
+
+    def __init__(self, lang):
+        if lang not in self.LANGUAGES:
+            raise ValueError(f"lang must be one of {self.LANGUAGES}")
+        self.lang = lang
+
+    def tokenize(self, text):
+        return text.replace("—", "— ").split()
+
+    def strip_token(self, token):
+        return token.strip(",.?:;·—")
+
+    def _headers(self):
+        return dict(Accept="application/json")
+
+    def _build_params(self, form):
+        raise Exception("Must provide implementation on a per service basis.")
+
+    def _response_to_lemmas(self, response):
+        raise Exception("Must provide implementation on a per service basis.")
+
+    def _call_service(self, form):
+        params = self._build_params(form)
+        headers = self._headers()
+        response = requests.get(self.ENDPOINT, params=params, headers=headers)
+        return self._response_to_lemmas(response)
+
+    def lemmatize(self, form):
+        return self._call_service(form)
+

--- a/lemmatization/services/clancydb.py
+++ b/lemmatization/services/clancydb.py
@@ -1,44 +1,37 @@
-from urllib.parse import urlencode
+from .base import Service
 
-import requests
 
-SID = "clancydb"
-
-LANGUAGES = ("rus",)
-
-def lemmatize_word(form, lang):
+class ClancyService(Service):
     """
     headword/lemma retrieval from Steven Clancy's russian database.
 
-    >>> lemmatize_word("газету", "rus")
+    >>> clancy = ClancyService(lang="rus")
+    >>> clancy.lemmatize("газету")
     ['газета']
-    >>> lemmatize_word("дела", "rus")
+    >>> clancy.lemmatize("дела")
     ['дело', 'деть']
-    >>> lemmatize_word("ру́сская", "rus")
+    >>> clancy.lemmatize("ру́сская")
     ['русский']
-    >>> lemmatize_word("все", "rus")
+    >>> clancy.lemmatize("все")
     ['весь', 'все', 'всё']
-    >>> lemmatize_word("мороженое", "rus")
+    >>> clancy.lemmatize("мороженое")
     ['мороженый', 'мороженое']
     """
 
-    if lang not in LANGUAGES:
-        raise ValueError(f"lang must be one of {LANGUAGES}")
+    SID = "clancydb"
+    LANGUAGES = ["rus"]
+    ENDPOINT = "http://visualizingrussian.fas.harvard.edu/api/lemmatize"
 
-    params = {"word": form}
-    qs = urlencode(params)
-    url = f"http://visualizingrussian.fas.harvard.edu/api/lemmatize?{qs}"
-    headers = {
-        "Accept": "application/json",
-    }
-    r = requests.get(url, headers=headers)
-    if r.ok:
-        body = r.json().get("data", {}).get("lemmas", [])
-        if not isinstance(body, list):
-            body = [] 
-    else:
-        body = []
+    def _build_params(self, form):
+        return dict(word=form)
 
-    lemmas = [item["label"] for item in body]
-    return lemmas
+    def _response_to_lemmas(self, response):
+        if response.ok:
+            body = response.json().get("data", {}).get("lemmas", [])
+            if not isinstance(body, list):
+                body = []
+        else:
+            body = []
 
+        lemmas = [item["label"] for item in body]
+        return lemmas

--- a/lemmatization/services/morpheus.py
+++ b/lemmatization/services/morpheus.py
@@ -1,44 +1,36 @@
-from urllib.parse import urlencode
+from .base import Service
 
-import requests
 
-SID = "morpheus"
-
-LANGUAGES = ("grc", "lat")
-
-def lemmatize_word(form, lang):
+class MorpheusService(Service):
     """
     headword/lemma retrieval from the Perseids Morphology Service
 
-    >>> lemmatize_word("λόγος", "grc")
+    >>> morpheus_grc = MorpheusService(lang="grc")
+    >>> morpheus_grc.lemmatize("λόγος")
     ['λόγος']
-    >>> lemmatize_word("est", "lat")
+
+    >>> morpheus_lat = MorpheusService(lang="lat")
+    >>> morpheus_lat.lemmatize("est")
     ['edo1', 'sum1']
     """
 
-    if lang not in LANGUAGES:
-        raise ValueError(f"lang must be one of {LANGUAGES}")
 
-    params = {
-        "word": form,
-        "lang": lang,
-        "engine": f"morpheus{lang}",
-    }
-    qs = urlencode(params)
-    url = f"http://services.perseids.org/bsp/morphologyservice/analysis/word?{qs}"
-    headers = {
-        "Accept": "application/json",
-    }
-    r = requests.get(url, headers=headers)
-    if r.ok:
-        body = r.json().get("RDF", {}).get("Annotation", {}).get("Body", [])
-        if not isinstance(body, list):
-            body = [body]
-    else:
-        body = []
+    SID = "morpheus"
+    LANGUAGES = ["grc", "lat"]
+    ENDPOINT = "http://services.perseids.org/bsp/morphologyservice/analysis/word"
 
-    lemmas = []
-    for item in body:
-        lemmas.append(item["rest"]["entry"]["dict"]["hdwd"]["$"])
+    def _build_params(self, form):
+        return dict(word=form, lang=self.lang, engine=f"morpheus{self.lang}")
 
-    return lemmas
+    def _response_to_lemmas(self, response):
+        if response.ok:
+            body = response.json().get("RDF", {}).get("Annotation", {}).get("Body", [])
+            if not isinstance(body, list):
+                body = [body]
+        else:
+            body = []
+
+        lemmas = []
+        for item in body:
+            lemmas.append(item["rest"]["entry"]["dict"]["hdwd"]["$"])
+        return lemmas

--- a/lemmatized_text/models.py
+++ b/lemmatized_text/models.py
@@ -4,7 +4,7 @@ from django.contrib.postgres.fields import JSONField
 
 from django_rq import job
 
-from lemmatization.lemmatizer import lemmatize_text
+from lemmatization.lemmatizer import Lemmatizer
 
 
 @job
@@ -15,7 +15,8 @@ def lemmatize_text_job(text, lang, pk):
         obj.completed = int(percentage * 100)
         obj.save()
 
-    obj.data = lemmatize_text(text, lang, cb=update)
+    lemmatizer = Lemmatizer(lang, cb=update)
+    obj.data = lemmatizer.lemmatize(text)
     obj.save()
 
 


### PR DESCRIPTION
When pulling out tokenization I noticed there was a token stripping line that seemed like it might be language specific so I pulled that out as well.  That led me down the path of refactoring all the common factors between the two services into a base class which keeps the service implementations focused.

Local smoke testing seems to pass for me but probably best if @arthurian could review my changes.

Refs #76 