### PR TITLE
Revert pull request #161 to fix freezing-page problem

### DIFF
--- a/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
+++ b/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
@@ -7,8 +7,7 @@
       </span>
     </h4>
     <p>{{ description }}</p>
-    <gauge-chart :rate="knownVocab" label="Known (Unweighted)" />
-    <gauge-chart :rate="weightedKnownVocab" label="Known (Weighted)" />
+    <gauge-chart :rate="knownVocab" label="Known" />
     <div class="toggle-link-container">
       <span v-if="showInVocabList">
         The known words are highlighted.
@@ -36,9 +35,6 @@
       },
       knownVocab() {
         return this.$store.getters.knownVocab;
-      },
-      weightedKnownVocab() {
-        return this.$store.getters.weightedKnownVocab;
       },
       showInVocabList() {
         return this.$store.state.showInVocabList;

--- a/static/src/js/app/vuex/getters.js
+++ b/static/src/js/app/vuex/getters.js
@@ -5,37 +5,6 @@ export default {
     const knownTokens = tokens.filter(t => t.inVocabList).length;
     return knownTokens / totalTokens;
   },
-  weightedKnownVocab: (state) => {
-    const tokens = state.tokens.filter(t => t.word === t.word.toLowerCase());
-
-    // Create a set of unique tokens
-    const uniqueTokens = new Set();
-    for (let i = 0; i < tokens.length; i + 1) {
-      if (tokens[i].resolved !== 'na') {
-        if (tokens[i].label) {
-          // Looks like 'label' stores the lemma
-          uniqueTokens.add(tokens[i].label);
-        } else {
-          // If there is no lemma, use the word as is
-          uniqueTokens.add(tokens[i].word);
-        }
-      }
-    }
-
-    // Determine which tokens in the set of unique tokens are known,
-    // and put them in a new set
-    const knownUniqueTokens = new Set();
-    for (let i = 0; i < tokens.length; i + 1) {
-      if (tokens[i].inVocabList) {
-        knownUniqueTokens.add(tokens[i].label);
-      }
-    }
-
-    const totalUniqueTokens = uniqueTokens.size;
-    const totalKnownUniqueTokens = knownUniqueTokens.size;
-    // Return proportion of known unique tokens, which is equivalent to weighted percentage
-    return totalKnownUniqueTokens / totalUniqueTokens;
-  },
   selectedToken: (state) => {
     if (state.selectedIndex !== null && state.tokens.length > 0) {
       return state.tokens[state.selectedIndex];


### PR DESCRIPTION
Pull request #161 was the one introducing a second visualization to display weighted percentage of known words. The reason for undoing the pull request is that the changes introduced seem to be the cause of the browser-page-freeze that happens when you click the vocab list dropdown and select a vocab list. The reason for the freeze is likely that the changes introduced in the pull request are a bit heavy to run on the front-end. I noticed that when you open the Chrome Task Manager and select a vocab list, the CPU usage spikes to 100+ and stays as such indefinitely. Thus, perhaps the computation introduced in the PR is heavy for running on the front-end or there is a bug in the code change in that PR. The real reason is yet TBD. At any rate, reverting the pull request resolves the problem.

Ideally, I would have tracked down the problem in pull request #161 and fixed the bug. But a hotfix is needed for the freezing-page problem. This is the hotfix; i.e. reverting the PR. A proper solution will be provided later.