### PR TITLE
Proposed: tokenization updates to allow for language-specific rules

### DIFF
--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -7,6 +7,7 @@ from lattices.models import LatticeNode, LemmaNode
 from .models import add_form, lookup_form
 from .services.clancy import ClancyService
 from .services.morpheus import MorpheusService
+from .tokenizer import RUSTokenizer, Tokenizer
 
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,11 @@ SERVICES = {
     "lat": MorpheusService(lang="lat"),
     "grc": MorpheusService(lang="grc"),
     "rus": ClancyService(lang="rus"),
+}
+TOKENIZERS = {
+    "lat": Tokenizer(lang="lat"),
+    "grc": Tokenizer(lang="grc"),
+    "rus": RUSTokenizer(lang="rus"),
 }
 
 RESOLVED_NA = "na"
@@ -35,11 +41,14 @@ class Lemmatizer(object):
         self.cb = cb
         self.force_refresh = force_refresh
         self._service = SERVICES.get(lang)
+        self._tokenizer = TOKENIZERS.get(lang)
         if self._service is None:
             raise ValueError(f"Lemmatization not supported for language '{lang}''")
+        if self._tokenizer is None:
+            raise ValueError(f"Tokenization not supported for language '{lang}''")
 
     def _tokenize(self, text):
-        return self._service.tokenize(text)
+        return self._tokenizer.tokenize(text)
 
     def _lemmatize_token(self, token):
         s = lookup_form(token)

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -72,9 +72,9 @@ class Lemmatizer(object):
         tokens = list(self._tokenize(text))
         total_count = len(tokens)
         for index, token in enumerate(tokens):
-            word, following = token
-            if word:
-                lemmas = self._lemmatize_token(word)
+            word, word_normalized, following = token
+            if word_normalized:
+                lemmas = self._lemmatize_token(word_normalized)
 
                 # node = get_lattice_node(lemmas, word)  # @@@ not sure what to use for context here
 
@@ -134,6 +134,7 @@ class Lemmatizer(object):
             node_pk = node.pk if node else None
             result.append(dict(
                 word=word,
+                word_normalized=word_normalized,
                 following=following,
                 node=node_pk,
                 resolved=resolved

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -1,21 +1,4 @@
-import re
-
 import requests
-
-
-def pairwise(iterable):
-    """s -> (s0, s1), (s2, s3), (s4, s5), ..."""
-    a = iter(iterable)
-    return zip(a, a)
-
-
-def tokenize(text):
-    """text -> [w0, _, w1, _, w2, _, ...]"""
-    tokens = re.split(r"(\W+)", text)
-    # test to make sure there is an even number of items in array
-    if len(tokens) % 2 > 0:
-        tokens.append(" ")
-    return tokens
 
 
 class Service(object):
@@ -28,15 +11,6 @@ class Service(object):
         if lang not in self.LANGUAGES:
             raise ValueError(f"lang must be one of {self.LANGUAGES}")
         self.lang = lang
-
-    def tokenize(self, text):
-        """
-        Returns pairs of: (word, following)
-
-        The first item returned will have an empty string for `word` if the
-        text starts with a non-word.
-        """
-        return pairwise(tokenize(text))
 
     def _headers(self):
         return dict(Accept="application/json")

--- a/lemmatization/tokenizer.py
+++ b/lemmatization/tokenizer.py
@@ -91,7 +91,7 @@ class RUSTokenizer(Tokenizer):
         Splits hyphenated tokens with some exceptions for prefixes/suffixes.
         """
         prefixes = ("по-", "кое-")
-        suffixes = ("-либо", "-ка",  "-нибудь", "-то")
+        suffixes = ("-либо", "-ка", "-нибудь", "-то")
         processed = []
         for token in tokens:
             if "-" in token:

--- a/lemmatization/tokenizer.py
+++ b/lemmatization/tokenizer.py
@@ -1,0 +1,87 @@
+import re
+import unicodedata
+
+
+def pairwise(iterable):
+    """s -> (s0, s1), (s2, s3), (s4, s5), ..."""
+    a = iter(iterable)
+    return zip(a, a)
+
+
+def eveniter(iterable, last=" "):
+    """ Generates an even number of values. """
+    even = True
+    for value in iterable:
+        even = not even
+        yield value
+    if not even:
+        yield last
+
+
+def maketrans_remove(accents=("COMBINING ACUTE ACCENT", "COMBINING GRAVE ACCENT")):
+    """ Makes a translation for removing accents from a string. """
+    return str.maketrans("", "", "".join([unicodedata.lookup(a) for a in accents]))
+
+
+class Tokenizer(object):
+    """
+    Tokenizer for breaking text into a list of tokens.
+
+    Subclasses should override the tokenize() method to provide
+    language-specific tokenization.
+    """
+
+    def __init__(self, lang):
+        self.lang = lang
+
+    def tokenize(self, text):
+        """
+        Returns an iterable of pairs: (word, following)
+
+        The first item returned will have an empty string for `word` if the
+        text starts with a non-word.
+        """
+        text = unicodedata.normalize("NFC", text)
+        tokens = re.split(r"(\W+)", text)
+        return pairwise(eveniter(tokens))
+
+
+class RUSTokenizer(Tokenizer):
+    """
+    Tokenizer for Russian.
+    """
+    TRANSLATION_REMOVE_ACCENTS = maketrans_remove(accents=(
+        "COMBINING ACUTE ACCENT",
+        "COMBINING GRAVE ACCENT",
+        "COMBINING X ABOVE"
+    ))
+
+    def tokenize(self, text):
+        # The logic below ensures that accented words aren't split
+        # and that certain hyphenated words are treated as a single token.
+        # For reference:
+        #   0400-04FF is the cyrillic unicode block
+        #   0300-036F is the combining diacritical marks block
+        text = unicodedata.normalize("NFC", text)  # normalize
+        tokens = re.split(r"([^-\u0400-\u04FF\u0300-\u036F]+)", text)
+        tokens = self._process(tokens)
+        return pairwise(eveniter(tokens))
+
+    def _normalize(self, token):
+        token = unicodedata.normalize("NFD", token)
+        token = token.translate(self.TRANSLATION_REMOVE_ACCENTS)
+        return unicodedata.normalize("NFC", token)
+
+    def _process(self, tokens):
+        processed = []
+        for token in tokens:
+            token = self._normalize(token)
+            if "-" in token:
+                if token.startswith("по-") or token.endswith("-то"):
+                    processed.append(token)
+                else:
+                    for t in re.split(r"(-)", token):
+                        processed.append(t)
+            else:
+                processed.append(token)
+        return processed


### PR DESCRIPTION
This is a proposed change to (a) allow for more language-specific tokenization rules and (b) allow for words to be matched against a normalized form. It includes a minimal proof of concept for russian that handles accented text and common hyphenated words that should not be split.

The tokenized response includes both the original word and a normalized form for internal matching as suggested in #137. For latin/greek it currently returns the word as-is.

```
(word, following) => (word, normalized, following)
```

Thoughts?