### PR TITLE
Customize font for reading

### DIFF
--- a/hedera/templates/site_base.html
+++ b/hedera/templates/site_base.html
@@ -8,7 +8,7 @@
 
 
 {% block styles %}
-  <link href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=greek,greek-ext,latin-ext" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=greek,greek-ext,latin-ext,russian" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700" rel="stylesheet">
 
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="{%  static 'src/favicons/apple-touch-icon-57x57.png' %}" />


### PR DESCRIPTION
This PR updates the [Noto](https://www.google.com/get/noto/) font definition so that russian text, particularly accented text, is rendered correctly. 

Example before and after: 

![noto-serif](https://user-images.githubusercontent.com/1165361/80617487-2c908500-8a10-11ea-8137-55d76eb0af0c.png)

![not-serif-russian](https://user-images.githubusercontent.com/1165361/80631166-53a48200-8a23-11ea-92d3-91c95a4ab260.png)

(Edited per discussion below)