### PR TITLE
Restore weighted percentage chart with bugfix

### DIFF
--- a/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
+++ b/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
@@ -7,7 +7,8 @@
       </span>
     </h4>
     <p>{{ description }}</p>
-    <gauge-chart :rate="knownVocab" label="Known" />
+    <gauge-chart :rate="knownVocab" label="Known (Unweighted)" />
+    <gauge-chart :rate="weightedKnownVocab" label="Known (Weighted)" />
     <div class="toggle-link-container">
       <span v-if="showInVocabList">
         The known words are highlighted.
@@ -35,6 +36,9 @@
       },
       knownVocab() {
         return this.$store.getters.knownVocab;
+      },
+      weightedKnownVocab() {
+        return this.$store.getters.weightedKnownVocab;
       },
       showInVocabList() {
         return this.$store.state.showInVocabList;

--- a/static/src/js/app/vuex/getters.js
+++ b/static/src/js/app/vuex/getters.js
@@ -5,6 +5,37 @@ export default {
     const knownTokens = tokens.filter((t) => t.inVocabList).length;
     return knownTokens / totalTokens;
   },
+  weightedKnownVocab: (state) => {
+    const tokens = state.tokens.filter((t) => t.word === t.word.toLowerCase());
+
+    // Create a set of unique tokens
+    const uniqueTokens = new Set();
+    for (let i = 0; i < tokens.length; i += 1) {
+      if (tokens[i].resolved !== 'na') {
+        if (tokens[i].label) {
+          // Looks like 'label' stores the lemma
+          uniqueTokens.add(tokens[i].label);
+        } else {
+          // If there is no lemma, use the word as is
+          uniqueTokens.add(tokens[i].word);
+        }
+      }
+    }
+
+    // Determine which tokens in the set of unique tokens are known,
+    // and put them in a new set
+    const knownUniqueTokens = new Set();
+    for (let i = 0; i < tokens.length; i += 1) {
+      if (tokens[i].inVocabList) {
+        knownUniqueTokens.add(tokens[i].label);
+      }
+    }
+
+    const totalUniqueTokens = uniqueTokens.size;
+    const totalKnownUniqueTokens = knownUniqueTokens.size;
+    // Return proportion of known unique tokens, which is equivalent to weighted percentage
+    return totalKnownUniqueTokens / totalUniqueTokens;
+  },
   selectedToken: (state) => {
     if (state.selectedIndex !== null && state.tokens.length > 0) {
       return state.tokens[state.selectedIndex];


### PR DESCRIPTION
The weighted percentage chart was removed for the reason explained in https://github.com/Hedera-Lang-Learn/hedera/pull/175

The bug was that the loop variables of the for-loops were not incrementing, thereby causing infinite loops.

This PR returns the weighted percentage chart while fixing the for-loop constructs to get rid of the bug.