### PR TITLE
Normalize i/j and u/v spelling for latin 

### DIFF
--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -7,7 +7,7 @@ from lattices.models import LatticeNode, LemmaNode
 from .models import add_form, lookup_form
 from .services.clancy import ClancyService
 from .services.morpheus import MorpheusService
-from .tokenizer import RUSTokenizer, Tokenizer
+from .tokenizer import LATTokenizer, RUSTokenizer, Tokenizer
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ SERVICES = {
     "rus": ClancyService(lang="rus"),
 }
 TOKENIZERS = {
-    "lat": Tokenizer(lang="lat"),
+    "lat": LATTokenizer(lang="lat"),
     "grc": Tokenizer(lang="grc"),
     "rus": RUSTokenizer(lang="rus"),
 }
@@ -84,7 +84,7 @@ class Lemmatizer(object):
                 lemma_node = LemmaNode.objects.filter(
                     context=context,
                     lemma=label).first()
-                logger.debug(f"lemmatize {context} -> {word} {lemmas} {label}")
+                logger.debug(f"lemmatize {context} -> {word} {word_normalized} {lemmas} {label}")
 
                 if lemma_node:
                     node = lemma_node.node

--- a/lemmatization/tokenizer.py
+++ b/lemmatization/tokenizer.py
@@ -55,6 +55,27 @@ class Tokenizer(object):
         return triples(tokens)
 
 
+class LATTokenizer(Tokenizer):
+    """
+    Tokenizer for Latin.
+    """
+    TRANSLATION_SPELLING = str.maketrans("jJuU", "iIvV")
+
+    def tokenize(self, text):
+        """
+        Returns an iterable of triples: (word, word_normalized, following)
+        """
+        text = unicodedata.normalize("NFC", text)
+        tokens = re.split(r"(\W+)", text)
+        return triples(tokens, normalize=self._normalize)
+
+    def _normalize(self, token):
+        """
+        Normalizes spelling (j->i, u->v).
+        """
+        return token.translate(self.TRANSLATION_SPELLING)
+
+
 class RUSTokenizer(Tokenizer):
     """
     Tokenizer for Russian.


### PR DESCRIPTION
This PR is a first pass at normalizing j/i and u/v for internal matching (#137). It just does a simple replacement of j->i, u->v. 

Are there additional rules that need to be considered for this sort of spelling normalization or is this sufficient?