### PR TITLE
Add flatpages for staff maintained content

### DIFF
--- a/fixtures/flatpages.json
+++ b/fixtures/flatpages.json
@@ -1,0 +1,38 @@
+[
+{
+    "model": "flatpages.flatpage",
+    "pk": 1,
+    "fields": {
+        "url": "/about/",
+        "title": "About",
+        "content": "<h1>Demo About Page</h1>\r\n\r\n<p class=\"lead\">This is some default about content.</p>\r\n\r\n<p>You can use regular HTML and classes like <code>lead</code> that come with <a href=\"https://getbootstrap.com/\">Bootstrap</a></p>\r\n\r\n<p>Adding new pages will make them appear automatically in the side nav.</p>",
+        "enable_comments": false,
+        "template_name": "",
+        "registration_required": false,
+        "sites": [
+            2,
+            4,
+            1,
+            3
+        ]
+    }
+},
+{
+    "model": "flatpages.flatpage",
+    "pk": 2,
+    "fields": {
+        "url": "/about/history/",
+        "title": "Project History",
+        "content": "this is some content for the history of Hedera",
+        "enable_comments": false,
+        "template_name": "",
+        "registration_required": false,
+        "sites": [
+            2,
+            4,
+            1,
+            3
+        ]
+    }
+}
+]

--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -171,6 +171,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "django.contrib.flatpages",
     "django.contrib.messages",
     "django.contrib.sessions",
     "django.contrib.sites",

--- a/hedera/templates/flatpages/default.html
+++ b/hedera/templates/flatpages/default.html
@@ -1,0 +1,25 @@
+{% extends "site_base.html" %}
+
+{% load flatpages %}
+{% load i18n %}
+
+{% block head_title %}{{ flatpage.title }}{% endblock %}
+
+{% block body_class %}flatpage{% endblock %}
+
+{% block site_brand %}{% endblock %}
+{% block navbar-toggler %}{% endblock %}
+
+{% block body %}
+  {% get_flatpages as flatpages %}
+  <div class="row">
+    <div class="col-4">
+        <ul class="nav flex-column text-right">
+            {% for page in flatpages %}
+                <li class="nav-item"><a class="nav-link {% if flatpage == page %}active{% endif %}" href="{{ page.url }}">{{ page.title }}</a></li>
+            {% endfor %}
+        </ul>
+    </div>
+    <div class="col-8">{{ flatpage.content|safe }}</div>
+  </div>
+{% endblock %}

--- a/hedera/templates/site_base.html
+++ b/hedera/templates/site_base.html
@@ -54,6 +54,7 @@
           {% block nav %}
             <ul class="navbar-nav mr-auto">
               {% block nav_items %}
+                <li class="navbar-item"><a class="nav-link" href="/about/">About</a></li>
               {% if request.user.is_authenticated %}
                 <li class="navbar-item"><a class="nav-link" href="{% url 'lemmatized_texts_list' %}">Lemmatized Texts</a></li>
                 <li class="navbar-item"><a class="nav-link" href="{% url 'vocab_list_list' %}">Vocabulary Lists</a></li>

--- a/hedera/urls.py
+++ b/hedera/urls.py
@@ -31,4 +31,6 @@ urlpatterns = [
     path("api/v1/vocab_entries/<int:pk>/link/", api.VocabularyListEntryAPI.as_view()),
     path("api/v1/personal_vocab_list/", api.PersonalVocabularyListAPI.as_view()),
     path("api/v1/personal_vocab_list/<int:pk>/", api.PersonalVocabularyListAPI.as_view()),
+
+    path("", include("django.contrib.flatpages.urls")),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_URL)

--- a/static/src/scss/_body.scss
+++ b/static/src/scss/_body.scss
@@ -11,3 +11,9 @@ body {
 p.lead b {
   font-weight: bold;
 }
+
+.nav-link.active {
+    border-right: 5px solid $primary;
+    margin-right: -5px;
+    background: rgba($primary, 0.1);
+}


### PR DESCRIPTION
* adds a top level nav link, "About" to `/about/`
* adds a flat pages app to Django admin, where you can create pages at any URL not already being used by the application
* renders content into a template with a left hand nav column that will auto generate links based on the pages you create
* comes with a fixture to create the first two pages for you that you can edit (after deploy run `./manage.py loaddata flatpages`
* The top level `/about/` is hard coded so you'll need to at least have that flatpage.  If you change the url in the `/about/` fixture, we'll need to change the url in the template for the navbar.

--
Ref #184 