### PR TITLE
Bulk disambiguation

### DIFF
--- a/hedera/api.py
+++ b/hedera/api.py
@@ -111,7 +111,8 @@ class LemmatizationAPI(APIView):
                 token["inVocabList"] = token["resolved"] and vl.entries.filter(node__pk=token["node"]).exists()
                 token["familiarity"] = token["resolved"] and vl.node_familiarity(token["node"])
 
-        for token in data:
+        for index, token in enumerate(data):
+            token["tokenIndex"] = index
             node = nodes.filter(pk=token["node"]).first()
             if node is not None:
                 token.update(node.gloss_data())

--- a/static/src/js/app/App.vue
+++ b/static/src/js/app/App.vue
@@ -6,7 +6,7 @@
       </div>
       <div class="col-4">
         <VocabListSelect class="mb-5" :vocab-lists="vocabLists" />
-        <LatticeTree v-if="selectedToken" :node="selectedNode" :index="selectedIndex" :token="selectedToken" />
+        <LatticeTree v-if="selectedToken" />
       </div>
     </div>
   </div>
@@ -43,13 +43,7 @@
         return this.$store.state.vocabLists;
       },
       selectedToken() {
-        return this.$store.getters.selectedToken;
-      },
-      selectedIndex() {
-        return this.$store.state.selectedIndex;
-      },
-      selectedNode() {
-        return this.selectedToken && this.$store.state.nodes[this.selectedToken.node];
+        return this.$store.state.selectedToken;
       },
     },
   };

--- a/static/src/js/app/Learner.vue
+++ b/static/src/js/app/Learner.vue
@@ -193,7 +193,7 @@
         return this.selectedNode && this.selectedNode.vocabulary_entries;
       },
       selectedToken() {
-        return this.$store.getters.selectedToken;
+        return this.$store.state.selectedToken;
       },
       selectedNode() {
         return this.selectedToken && this.$store.state.nodes[this.selectedToken.node];

--- a/static/src/js/app/modules/LatticeNode.vue
+++ b/static/src/js/app/modules/LatticeNode.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="lattice-node" v-if="node">
-    <LatticeNode v-for="parent in parents" :key="parent.pk" :node="parent" @selected="n => $emit('selected', n)" :selectedToken="selectedToken" />
+    <LatticeNode v-for="parent in parents" :key="parent.pk" :node="parent" @selected="n => $emit('selected', n)" />
     <div class="lattice-node--heading" @click.prevent="onClick">
       <div>
         <span class="lattice-id">{{ node.pk }}.</span>
@@ -10,14 +10,14 @@
         <span class="lattice-gloss">{{ node.gloss }}</span>
       </div>
     </div>
-    <LatticeNode v-for="child in children" :key="child.pk" :node="child" @selected="n => $emit('selected', n)" :selectedToken="selectedToken" />
+    <LatticeNode v-for="child in children" :key="child.pk" :node="child" @selected="n => $emit('selected', n)" />
   </div>
 </template>
 <script>
-  const formFilter = (node, selectedToken) => {
+  const formFilter = (node, selectedWord) => {
     if (node.forms.length > 0) {
       /* remove trailing punctuation */
-      const strippedToken = selectedToken.replace(/[,.?:;·—]+$/, '');
+      const strippedToken = selectedWord.replace(/[,.?:;·—]+$/, '');
       if (node.forms[0].form === strippedToken) {
         return true;
       }
@@ -27,19 +27,22 @@
   };
 
   export default {
-    props: ['node', 'selectedToken'],
     name: 'LatticeNode',
+    props: ['node'],
     methods: {
       onClick() {
         this.$emit('selected', this.node);
       },
     },
     computed: {
+      selectedWord() {
+        return this.selectedToken && this.selectedToken.word;
+      },
       parents() {
-        return this.node.parents && this.node.parents.filter((node) => formFilter(node, this.selectedToken));
+        return this.node.parents && this.node.parents.filter((node) => formFilter(node, this.selectedWord));
       },
       children() {
-        return this.node.children && this.node.children.filter((node) => formFilter(node, this.selectedToken));
+        return this.node.children && this.node.children.filter((node) => formFilter(node, this.selectedWord));
       },
       vocabEntries() {
         return this.node.vocabulary_entries;

--- a/static/src/js/app/modules/LatticeTree.vue
+++ b/static/src/js/app/modules/LatticeTree.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="lattice-tree">
-    <h4>{{ token.word }}</h4>
-    <LatticeNode :node="node" @selected="onSelect" :selectedToken="selectedToken" />
+    <h4>{{ selectedToken.word }}</h4>
+    <LatticeNode :node="selectedNode" @selected="onSelect" />
     <AddLemma @addLemma="onAddLemma" />
-    <MarkResolved :resolved="token.resolved" @toggle="markResolved" />
+    <MarkResolved />
   </div>
 </template>
 <script>
@@ -13,39 +13,33 @@
   import { UPDATE_TOKEN, ADD_LEMMA, RESOLVED_MANUAL } from '../constants';
 
   export default {
-    props: ['token', 'index', 'node'],
     components: { AddLemma, LatticeNode, MarkResolved },
     computed: {
       textId() {
         return this.$store.state.textId;
       },
+      selectedNode() {
+        return this.selectedToken && this.$store.state.nodes[this.selectedToken.node];
+      },
       selectedToken() {
-        return this.$store.getters.selectedToken.word;
+        return this.$store.state.selectedToken;
       },
     },
     methods: {
       onAddLemma({ lemma }) {
         this.$store.dispatch(ADD_LEMMA, {
           id: this.textId,
-          tokenIndex: this.index,
+          tokenIndex: this.selectedToken.tokenIndex,
           lemma,
-          resolved: this.token.resolved,
+          resolved: this.selectedToken.resolved,
         });
       },
       onSelect(node) {
         this.$store.dispatch(UPDATE_TOKEN, {
           id: this.textId,
-          tokenIndex: this.index,
+          tokenIndex: this.selectedToken.tokenIndex,
           nodeId: node.pk,
           resolved: RESOLVED_MANUAL,
-        });
-      },
-      markResolved({ resolved }) {
-        this.$store.dispatch(UPDATE_TOKEN, {
-          id: this.textId,
-          tokenIndex: this.index,
-          nodeId: this.node ? this.node.pk : null,
-          resolved,
         });
       },
     },

--- a/static/src/js/app/modules/LemmatizedText.vue
+++ b/static/src/js/app/modules/LemmatizedText.vue
@@ -143,7 +143,7 @@
         return this.$store.getters.selectedToken;
       },
       sameWords() {
-        return this.tokens.filter((t) => this.selectedToken && t.word === this.selectedToken.word);
+        return this.$store.getters.sameWords;
       },
     },
   };

--- a/static/src/js/app/modules/LemmatizedText.vue
+++ b/static/src/js/app/modules/LemmatizedText.vue
@@ -1,12 +1,10 @@
 <template>
   <div class="lemmatized-text" :class="highlightClass">
-    <template v-for="(token, index) in tokens">
+    <template v-for="token in tokens">
       <Token
-        :key="index"
+        :key="token.tokenIndex"
         :token="token"
-        :index="index"
         :selected-token="selectedToken"
-        :selected-index="selectedIndex"
         :same-words="sameWords"
         :class="familiarityClass(token)"
         @toggleSelected="onToggleSelect"
@@ -70,6 +68,7 @@
     },
     methods: {
       selectToken(index) {
+        const token = this.tokens[index];
         const fetchNode = () => {
           if (this.selectedToken.node !== null) {
             this.$store.dispatch(FETCH_NODE, { id: this.selectedToken.node });
@@ -79,26 +78,26 @@
 
         // The debounce is delaying the call but it's accumulating all the instances
         // so the network call is happening multiple times.
-        this.$store.dispatch(SELECT_TOKEN, { index })
+        this.$store.dispatch(SELECT_TOKEN, { token })
           .then(debouncedFetchNode());
       },
-      onToggleSelect({ token, index }) {
-        if (this.selectedIndex === index && this.selectedToken === token) {
-          this.$store.dispatch(SELECT_TOKEN, { index: null });
+      onToggleSelect(token) {
+        if (this.selectedToken === token) {
+          this.$store.dispatch(SELECT_TOKEN, { token: null });
         } else {
-          this.selectToken(index);
+          this.selectToken(token.tokenIndex);
         }
       },
       goToWord(indexFunction) {
         let index = 0;
-        if (this.selectedIndex !== null) {
-          index = indexFunction(this.selectedIndex, this.tokens);
+        if (this.selectedToken !== null) {
+          index = indexFunction(this.selectedToken.tokenIndex, this.tokens);
         }
         this.selectToken(index);
       },
       goToUnresolved(indexFunction) {
         let index = 0;
-        if (this.selectedIndex !== null) {
+        if (this.selectedToken !== null) {
           const unresolvedTokenIndex = indexFunction(
             this.unresolvedTokens.indexOf(this.selectedToken),
             this.unresolvedTokens,
@@ -136,11 +135,8 @@
       tokens() {
         return this.$store.state.tokens;
       },
-      selectedIndex() {
-        return this.$store.state.selectedIndex;
-      },
       selectedToken() {
-        return this.$store.getters.selectedToken;
+        return this.$store.state.selectedToken;
       },
       sameWords() {
         return this.$store.getters.sameWords;

--- a/static/src/js/app/modules/MarkResolved.vue
+++ b/static/src/js/app/modules/MarkResolved.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="mark-resolved">
     <span class="status-label">{{ resolved }}</span>
-    <a href @click.prevent="toggleResolved" v-if="canChange">
+    <a class="btn btn-block" :class="isResolved ? 'btn-outline-secondary' : 'btn-primary'" href @click.prevent="toggleResolved" v-if="canChange">
       {{ label }}
+    </a>
+    <a class="btn btn-primary btn-block" href @click.prevent="resolveAll" v-if="canApplyAll">
+      Apply to All
     </a>
   </div>
 </template>
@@ -11,33 +14,66 @@
     RESOLVED_UNRESOLVED,
     RESOLVED_MANUAL,
     RESOLVED_AUTOMATIC,
+    UPDATE_TOKEN,
   } from '../constants';
 
   export default {
-    props: ['resolved'],
     computed: {
       label() {
         let label = this.resolved;
         if (this.resolved === RESOLVED_UNRESOLVED) {
           label = 'Mark Resolved';
-        } else if (this.resolved === RESOLVED_AUTOMATIC || this.resolved === RESOLVED_MANUAL) {
+        } else if (this.isResolved) {
           label = 'Mark Unresolved';
         }
         return label;
       },
+      isResolved() {
+        return this.resolved === RESOLVED_AUTOMATIC || this.resolved === RESOLVED_MANUAL;
+      },
       canChange() {
         return [RESOLVED_UNRESOLVED, RESOLVED_AUTOMATIC, RESOLVED_MANUAL].indexOf(this.resolved) > -1;
       },
+      resolved() {
+        return this.selectedToken.resolved;
+      },
+      selectedToken() {
+        return this.$store.state.selectedToken;
+      },
+      sameWords() {
+        return this.$store.getters.sameWords;
+      },
+      unresolvedOthers() {
+        return this.sameWords.filter((sw) => sw.tokenIndex !== this.selectedToken.tokenIndex && sw.resolved === RESOLVED_UNRESOLVED);
+      },
+      canApplyAll() {
+        return this.unresolvedOthers.length > 0
+          && [RESOLVED_AUTOMATIC, RESOLVED_MANUAL].indexOf(this.resolved) > -1;
+      },
     },
     methods: {
-      toggleResolved() {
-        let { resolved } = this;
-        if (this.resolved === RESOLVED_UNRESOLVED) {
+      resolveTo(token) {
+        let { resolved } = token;
+        if (token.resolved === RESOLVED_UNRESOLVED) {
           resolved = RESOLVED_MANUAL;
-        } else if (this.resolved === RESOLVED_AUTOMATIC || this.resolved === RESOLVED_MANUAL) {
+        } else if (token.resolved === RESOLVED_AUTOMATIC || token.resolved === RESOLVED_MANUAL) {
           resolved = RESOLVED_UNRESOLVED;
         }
-        this.$emit('toggle', { resolved });
+        return resolved;
+      },
+      updateToken(token) {
+        this.$store.dispatch(UPDATE_TOKEN, {
+          id: this.$store.state.textId,
+          tokenIndex: token.tokenIndex,
+          nodeId: token.node,
+          resolved: this.resolveTo(token),
+        });
+      },
+      toggleResolved() {
+        this.updateToken(this.selectedToken);
+      },
+      resolveAll() {
+        this.unresolvedOthers.forEach(this.updateToken);
       },
     },
   };
@@ -53,5 +89,7 @@
     background: $gray-200;
     border: 1px solid $gray-400;
     border-radius: 4px;
+    display: inline-block;
+    margin-bottom: 20px;
   }
 </style>

--- a/static/src/js/app/modules/Token.vue
+++ b/static/src/js/app/modules/Token.vue
@@ -10,15 +10,15 @@
 </template>
 <script>
   export default {
-    props: ['token', 'index', 'selectedIndex', 'selectedToken', 'sameWords'],
+    props: ['token', 'selectedToken', 'sameWords'],
     methods: {
       onClick() {
-        this.$emit('toggleSelected', { index: this.index });
+        this.$emit('toggleSelected', this.token);
       },
     },
     computed: {
       selected() {
-        return this.selectedIndex && this.selectedIndex === this.index;
+        return this.selectedToken && this.selectedToken.tokenIndex === this.token.tokenIndex;
       },
       sameNode() {
         return this.selectedToken && this.selectedToken.node === this.token.node;

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -59,7 +59,7 @@ export default {
       .fetchTokens(id, vocabList, personalVocabList, cb)
       .catch(logoutOnError(commit));
   },
-  [SELECT_TOKEN]: ({ commit }, { index }) => commit(SELECT_TOKEN, { index }),
+  [SELECT_TOKEN]: ({ commit }, { token }) => commit(SELECT_TOKEN, { token }),
   [FETCH_NODE]: ({ commit }, { id }) => api.fetchNode(id, (data) => commit(FETCH_NODE, data)),
   [UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, nodeId, resolved }) => {
     api

--- a/static/src/js/app/vuex/getters.js
+++ b/static/src/js/app/vuex/getters.js
@@ -5,14 +5,8 @@ export default {
     const knownTokens = tokens.filter((t) => t.inVocabList).length;
     return knownTokens / totalTokens;
   },
-  selectedToken: (state) => {
-    if (state.selectedIndex !== null && state.tokens.length > 0) {
-      return state.tokens[state.selectedIndex];
-    }
-    return null;
-  },
-  sameWords: (state, getters) => {
-    const selected = getters.selectedToken;
+  sameWords: (state) => {
+    const selected = state.selectedToken;
     return state.tokens.filter((t) => selected && t.word === selected.word);
   },
 };

--- a/static/src/js/app/vuex/getters.js
+++ b/static/src/js/app/vuex/getters.js
@@ -11,4 +11,8 @@ export default {
     }
     return null;
   },
+  sameWords: (state, getters) => {
+    const selected = getters.selectedToken;
+    return state.tokens.filter((t) => selected && t.word === selected.word);
+  },
 };

--- a/static/src/js/app/vuex/mutations.js
+++ b/static/src/js/app/vuex/mutations.js
@@ -27,8 +27,8 @@ export default {
   [FETCH_TOKENS]: (state, data) => {
     state.tokens = data;
   },
-  [SELECT_TOKEN]: (state, { index }) => {
-    state.selectedIndex = index;
+  [SELECT_TOKEN]: (state, { token }) => {
+    state.selectedToken = token;
   },
   [FETCH_NODE]: (state, data) => {
     state.nodes = {
@@ -38,7 +38,9 @@ export default {
   },
   [UPDATE_TOKEN]: (state, data) => {
     state.tokens = data;
-    state.selectedToken = state.tokens[state.selectedIndex];
+    if (state.selectedToken) {
+      state.selectedToken = state.tokens[state.selectedToken.tokenIndex];
+    }
   },
   [SET_VOCAB_LIST]: (state, id) => {
     state.selectedVocabList = id;

--- a/static/src/js/app/vuex/state.js
+++ b/static/src/js/app/vuex/state.js
@@ -2,7 +2,7 @@ export default {
   textId: null,
   text: {},
   tokens: [],
-  selectedIndex: null,
+  selectedToken: null,
   nodes: {},
   vocabLists: [],
   personalVocabList: null,


### PR DESCRIPTION
You can now select "Apply All" after marking a token as resolved if there are other matching tokens in the text to apply the same disambiguation to them in one go.

@jtauber Could you do a review of this for me.  There is a lot of changes to support this that could impact a lot of things.  I have tested it locally and fixed what I've found except for "Add a Lemma".  That's not working but when I went to troubleshoot it I don't see how it could possibly be working currently as the I don't see in the API handler where the data is being handled.  

I'll verify if this is indeed a regression or not later, but wanted to get this PR up and ready for review.  Regression or not, we need to fix the the ability to add a lemma but might not need to hold up this merge.