### PR TITLE
Fix django debug

### DIFF
--- a/docker-entrypoint-webserver-prod.sh
+++ b/docker-entrypoint-webserver-prod.sh
@@ -22,7 +22,7 @@ export EMAIL_USE_TLS=True
 export USE_S3=True
 export SITE_ID=4
 export REDIS_URL=`aws ssm get-parameter --name /hedera/prod/redis_url --output text --query Parameter.Value --region us-east-1`
-export DJANGO_DEBUG=False
+export DJANGO_DEBUG=0
 export RQ_ASYNC=1
 
 

--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -24,7 +24,10 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 BASE_DIR = PACKAGE_ROOT
 
-DEBUG = os.environ.get("DJANGO_DEBUG", True)
+try:
+    DEBUG = bool(int(os.environ.get("DJANGO_DEBUG", "1")))
+except ValueError:
+    DEBUG = False
 
 DATABASES = {
     "default": dj_database_url.config(default="postgres://localhost/hedera")
@@ -34,7 +37,7 @@ ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
     "hederaproject.org",
-    ".hederaproject.org",
+    "*.hederaproject.org",
 ]
 
 ALLOWED_HOSTS += get_ecs_task_ips()


### PR DESCRIPTION
This PR fixes django DEBUG so that is actually False in prod, as expected.

When you pass in 'False' into the 'DJANGO_DEBUG' env var, it is parsed as a True-ey string in settings.py, which is not what we want. Instead of 'False', set the DJANGO_DEBUG env var to 0. It is still a string, but it is Falsy.