### PR TITLE
Fix django ALLOWED_HOSTS for subdomains

### DIFF
--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -37,7 +37,7 @@ ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
     "hederaproject.org",
-    "*.hederaproject.org",
+    ".hederaproject.org",
 ]
 
 ALLOWED_HOSTS += get_ecs_task_ips()


### PR DESCRIPTION
This PR fixes ALLOWED_HOSTS for subdomains so that dev.hederaproject.org can work without throwing an error.