### PR TITLE
Remove installation of awscli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,3 @@ EXPOSE 80
 
 RUN npm rebuild node-sass
 RUN npm run build
-
-RUN pip install awscli


### PR DESCRIPTION
`awscli` was used to run AWS CLI commands in the docker entrypoint scripts. The commands were for reading environment variable values from the AWS Systems Manager Parameter Store. However, we moved that functionality [into the ECS Task Definition](https://github.com/Harvard-ATG/atg-ops-ecs/blob/master/terraform/dev/nonlti-hedera/container-definitions.json). And so we no longer need the awscli package.

I have tested the change. All good.