### PR TITLE
Update base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/python:3.7-rc-node
+FROM circleci/python:3.7-node
 USER root
 RUN mkdir -p /srv/code
 WORKDIR /srv/code


### PR DESCRIPTION
This PR simply updates the base image in the Dockerfile.

[The previous image](https://hub.docker.com/layers/circleci/python/3.7-rc-node/images/sha256-26b8a94f14ef32bba65e8d6ebb8363a617bc9e37d156139ae3e9abf960b50af1?context=explore) has not been updated in 2 years, and so the Dockerfile's build step was failing on account of node being out of date.

[The new image](https://hub.docker.com/layers/circleci/python/3.7-node/images/sha256-ae3a9bf963311574da177ba09a552aff95586555c0a275c8757a299bcaca055a?context=explore), on the other hand, is getting updated. For instance, the latest update is as of 17 hours ago at the time of this writing.