### PR TITLE
Enclitic tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ And finally, to start Django,
 ./manage.py runserver
 ```
 
-By default, the there is a background worker that will work synchronously (won't need the worker running to process the lemmatization).  If you want to process asynchronously locally:
+By default, there is a background worker that will work synchronously (won't need the worker running to process the lemmatization).  If you want to process asynchronously locally:
 
 ```
 export RQ_ASYNC=1

--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -419,4 +419,4 @@ PDF_SERVICE_TOKEN = os.environ.get("PDF_SERVICE_KEY")
 
 # SSL is terminated at the ELB so look for this header to know that we should be in ssl mode
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = bool(int(os.environ.get("SESSION_COOKIE_SECURE", "0")))

--- a/hedera/templates/lemmatized_text/create.html
+++ b/hedera/templates/lemmatized_text/create.html
@@ -29,7 +29,7 @@
     {% endif %}
     <div class="form-group">
       <label>Text</label>
-      <textarea name="text" class="form-control" rows="10">{{ cloned_from.text }}</textarea>
+      <textarea name="text" class="form-control" rows="10">{{ cloned_from.original_text }}</textarea>
     </div>
     <button class="btn btn-primary">Submit</button>
     <a class="btn btn-default" href="{% url 'lemmatized_texts_list' %}">Cancel</a>

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -7,7 +7,7 @@ from lattices.models import LatticeNode, LemmaNode
 from .models import add_form, lookup_form
 from .services.clancy import ClancyService
 from .services.morpheus import MorpheusService
-from .tokenizer import RUSTokenizer, Tokenizer
+from .tokenizer import EncliticTokenizer, RUSTokenizer, Tokenizer
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ SERVICES = {
     "rus": ClancyService(lang="rus"),
 }
 TOKENIZERS = {
-    "lat": Tokenizer(lang="lat"),
+    "lat": EncliticTokenizer(lang="lat"),
     "grc": Tokenizer(lang="grc"),
     "rus": RUSTokenizer(lang="rus"),
 }

--- a/lemmatization/tokenizer.py
+++ b/lemmatization/tokenizer.py
@@ -104,3 +104,52 @@ class RUSTokenizer(Tokenizer):
             else:
                 processed.append(token)
         return processed
+
+
+def re_tokenize_clitics(tokens):
+    for token in tokens:
+        if "_" in token:
+            yield token.replace("_", " ")
+        elif token == "|":
+            yield ""
+        else:
+            yield token
+
+
+LATIN_COPULA = [
+    "sum", "es", "est", "sumus", "estis", "sunt",
+    "eram", "eras", "erat", "eramus", "eratis", "erant",
+    "ero", "eris", "erit", "erimus", "eritis", "erunt",
+    "sim", "sis", "sit", "simus", "sitis", "sint",
+    "siem", "sies", "siet", "siemus", "sietis", "sient",
+    "essem", "esses", "esset", "essemus", "essetis", "essent",
+    "forem", "fores", "foret", "foremus", "foretis", "forent",
+    "esse", "fuisse", "iri", "fore",
+]
+
+
+def latin_periphrastic_normalizer(token):
+    if " " in token:
+        return " ".join(word for word in token.split() if word not in LATIN_COPULA)
+    else:
+        return token
+
+
+class EncliticTokenizer(Tokenizer):
+    """
+    a tokenizer that
+    _
+    |
+    """
+
+    def tokenize(self, text):
+        """
+        Returns an iterable of triples: (word, word_normalized, following)
+
+        The first item returned will have an empty string for `word` if the
+        text starts with a non-word.
+        """
+        text = unicodedata.normalize("NFC", text)
+        tokens = re.split(r"(\W+)", text)
+        tokens = list(re_tokenize_clitics(tokens))
+        return triples(tokens, normalize=latin_periphrastic_normalizer)

--- a/lemmatized_text/models.py
+++ b/lemmatized_text/models.py
@@ -44,7 +44,7 @@ class LemmatizedText(models.Model):
     title = models.CharField(max_length=100)
     lang = models.CharField(max_length=3)  # ISO 639.2
     cloned_from = models.ForeignKey("LemmatizedText", null=True, blank=True, on_delete=models.SET_NULL)
-    cloned_for = models.ForeignKey("groups.Group", null=True, on_delete=models.SET_NULL)
+    cloned_for = models.ForeignKey("groups.Group", null=True, blank=True, on_delete=models.SET_NULL)
     original_text = models.TextField()
     completed = models.IntegerField(default=0)
 


### PR DESCRIPTION
Primarily:

* implements `|` and `_` as a way of overriding tokenization (`|` splits a word into two tokens, `_` joins two words as a single token)
* if a multi-word token has a form of to be (from Ivy's list) only the other word is used for lemmatization
* clone `original_text` not tokenized `text` so above is not lost

This addresses #57 

Also:
* allow `LemmatizedText.cloned_for` to be blank in admin (couldn't edit `LemmatizedText` in admin otherwise)
* from upstream: disable SESSION_COOKIE_SECURE in local dev
* fixed typo in README