### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,32 @@ For local development:
 ```
 docker run --publish 9000:9000 --env X_API_KEY=test-secret eldarioninc/pdf-service
 ```
+
+## Contributing Guidelines
+
+### Linting
+
+This project uses `isort` for import sorting, `flake8` for Python linting, and various `eslint plugins` for Javascript linting.
+
+### Passing Builds via Github
+##### Python Linting
+- Install `isort` and `flake8` into either your local virtual environment terminal or directly into the Docker `hedera-postgres` container terminal
+    
+    ```bash
+    pip install isort flake8
+    ```
+    After installing you can now run the the `isort` command in the terminal to check import sorting
+    ```bash
+    isort -c **/*.py
+    ```
+    and then `flake8` command to lint python
+    ```bash
+    flake8 --show-source databasetext hedera lattices lemmatization lemmatized_text vocab_list lti
+    ```
+
+##### Javascript Linting
+- The linting packages should be installed from the setup instructions as noted above. We can run the following command in either your local terminal or in the docker `hedera-npm
+` container terminal
+    ```bash
+    npm run lint
+    ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This project uses `isort` for import sorting, `flake8` for Python linting, and v
     ```bash
     isort -c **/*.py
     ```
-    and then `flake8` command to lint python
+    and then run the following `flake8` command to lint python
     ```bash
     flake8 --show-source databasetext hedera lattices lemmatization lemmatized_text vocab_list lti
     ```


### PR DESCRIPTION
Updated the README.md with Contributing Guidelines sections which has local environment linting instructions so that code is linted before pushing up/PR

The instructions cover `isort`, `flake8` and `eslint` commands for Python and Javascript respectively.

I will also add a diagram for the project structure in the WIKI (WIP)

Note: I know that theres a way for pre-commit(can run linters) to run before code is committed upstream for Node/Javascript but im not sure about Django/Python. Can look into it more if we want to add something like this down the line.