### PR TITLE
fix flake8 precommit to check double quotes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: 3.9.2
     hooks:
       -   id: flake8
-          args: [--config, setup.cfg]
+          args: [--inline-quotes 'double', --config, setup.cfg]
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v7.30.0
     hooks:


### PR DESCRIPTION
Quick fix for flake8
- flake8 is not picking up the configuration setting for `inline-quotes = 'double'` so I added it in the args field in pre-commit-config.yaml