### PR TITLE
Paginate personal vocab entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1947,7 +1947,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -1969,7 +1969,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -4412,13 +4412,13 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -4767,6 +4767,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
+      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
     },
     "de-indent": {
       "version": "1.0.2",
@@ -5707,7 +5712,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5742,7 +5747,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5757,7 +5762,7 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -5803,7 +5808,7 @@
         "p-limit": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -9842,6 +9847,11 @@
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -12052,13 +12062,13 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -12944,7 +12954,7 @@
         "pump": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
           "dev": true,
           "requires": {
             "end-of-stream": "^1.1.0",
@@ -13113,7 +13123,7 @@
         "p-limit": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
           "dev": true,
           "requires": {
             "p-try": "^1.0.0"
@@ -14292,7 +14302,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -14923,7 +14933,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -15104,7 +15114,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "ssri": {
@@ -15958,6 +15968,15 @@
             "eslint-visitor-keys": "^1.1.0"
           }
         }
+      }
+    },
+    "vue-good-table": {
+      "version": "2.21.10",
+      "resolved": "https://registry.npmjs.org/vue-good-table/-/vue-good-table-2.21.10.tgz",
+      "integrity": "sha512-K7yD8LwW5ouJmMTjNyjnXK1qwm6/FPt4jt+xk+dYAlVPTikW5QWnY8WZHgsiAWWWq58l5oOzRw9wS1tAAWaj6g==",
+      "requires": {
+        "date-fns": "^2.17.0",
+        "lodash.isequal": "^4.5.0"
       }
     },
     "vue-hot-reload-api": {
@@ -16839,7 +16858,7 @@
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -16848,7 +16867,7 @@
         "tapable": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-          "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
           "dev": true
         },
         "which": {
@@ -17562,7 +17581,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash.debounce": "^4.0.8",
     "raw-loader": "^0.5.1",
     "vue": "^2.6.12",
+    "vue-good-table": "^2.21.10",
     "vue-keybindings": "^1.0.0",
     "vuex": "^3.5.1"
   },

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -4,24 +4,26 @@
        <QuickAddVocabForm class="mr-2 text-left" />
        <DownloadVocab :glosses="glosses" :with-familiarity="true" />
      </div>
-     <vue-good-table
+    <div v-if="personalVocabEntries">
+      <vue-good-table
        :columns="columns"
        :rows="personalVocabEntries"
        :pagination-options="paginationOptions"
        :search-options="searchOptions"
-     >
-      <template slot="table-row" slot-scope="props">
-        <div v-if="props.column.field == 'familiarity'" class="d-flex">
-          <FamiliarityRating :value="props.row.familiarity" @input="(rating) => onRatingChange(rating, props.row)" />
-          <button type="button" aria-label="delete" @click="deleteVocab(props.row.id)" style="padding-top: 0;">
-            <i class="fa fa-trash" aria-hidden="true"></i>
-          </button>
-        </div>
-        <div v-else>
-          {{props.formattedRow[props.column.field]}}
-        </div>
-      </template>
-     </vue-good-table>
+      >
+        <template slot="table-row" slot-scope="props">
+          <div v-if="props.column.field == 'familiarity'" class="d-flex">
+            <FamiliarityRating :value="props.row.familiarity" @input="(rating) => onRatingChange(rating, props.row)" />
+            <button type="button" aria-label="delete" @click="deleteVocab(props.row.id)" style="padding-top: 0;">
+              <i class="fa fa-trash" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div v-else>
+            {{props.formattedRow[props.column.field]}}
+          </div>
+        </template>
+      </vue-good-table>
+    </div>
   </div>
 </template>
 
@@ -64,7 +66,7 @@
           enabled: true,
           perPage: 25,
           perPageDropdown: [10, 25, 50, 100],
-          dropdownAllowAll: false,
+          dropdownAllowAll: true,
           mode: 'records',
         },
         columns: [

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -1,4 +1,5 @@
 <template>
+  <!--
   <table class="table personal-vocab">
     <thead>
       <tr>
@@ -39,22 +40,54 @@
       </td>
     </tr>
   </table>
+  -->
+  <div>
+     <div class="d-flex justify-content-between mb-2">
+       <QuickAddVocabForm class="mr-2 text-left" />
+       <DownloadVocab :glosses="glosses" :with-familiarity="true" />
+     </div>
+     <vue-good-table
+       :columns="columns"
+       :rows="personalVocabEntries"
+       :pagination-options="{enabled:true}"
+     >
+      <template slot="table-row" slot-scope="props">
+        <div v-if="props.column.field == 'familiarity'" class="d-flex">
+          <FamiliarityRating :value="props.row.familiarity" @input="(rating) => onRatingChange(rating, props.row)" />
+          <button type="button" aria-label="delete" @click="deleteVocab(props.row.id)" style="padding-top: 0;">
+            <i class="fa fa-trash" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div v-else>
+          {{props.formattedRow[props.column.field]}}
+        </div>
+      </template>
+     </vue-good-table>
+  </div>
 </template>
 
 <script>
+  import { VueGoodTable } from 'vue-good-table';
+
   import {
     FETCH_PERSONAL_VOCAB_LIST,
     UPDATE_VOCAB_ENTRY,
     FETCH_ME,
     DELETE_PERSONAL_VOCAB_ENTRY,
   } from './constants';
+
   import FamiliarityRating from './modules/FamiliarityRating.vue';
   import DownloadVocab from './components/DownloadVocab.vue';
   import QuickAddVocabForm from './components/quick-add-button';
 
   export default {
     props: ['lang'],
-    components: { FamiliarityRating, DownloadVocab, QuickAddVocabForm },
+    components: {
+      FamiliarityRating,
+      DownloadVocab,
+      QuickAddVocabForm,
+      VueGoodTable,
+    },
     watch: {
       lang: {
         immediate: true,
@@ -62,6 +95,15 @@
           this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, { lang: this.lang });
         },
       },
+    },
+    data() {
+      return {
+        columns: [
+          { label: 'Headword', field: 'headword' },
+          { label: 'Gloss', field: 'gloss' },
+          { label: 'Familiarity', field: 'familiarity' },
+        ],
+      };
     },
     created() {
       this.$store.dispatch(FETCH_ME);

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -1,46 +1,4 @@
 <template>
-  <!--
-  <table class="table personal-vocab">
-    <thead>
-      <tr>
-        <th colspan="3" class="text-right">
-          <div class="d-flex float-right">
-            <DownloadVocab :glosses="glosses" :with-familiarity="true" />
-            <QuickAddVocabForm class="ml-2 text-left" />
-          </div>
-        </th>
-      </tr>
-    </thead>
-    <colgroup>
-      <col style="width: 20%" />
-      <col style="width: 40%" />
-      <col style="width: 40%" />
-    </colgroup>
-    <tr>
-      <th>Headword</th>
-      <th id="td-no-padding-left">Gloss</th>
-      <th id="td-no-padding-left-right">Familiarity</th>
-    </tr>
-    <tr v-for="entry in personalVocabEntries" :key="entry.id">
-      <td>{{ entry.headword }}</td>
-      <td id="td-no-padding-left">{{ entry.gloss }}</td>
-      <td nowrap id="td-familiarity-rating">
-        <FamiliarityRating
-          :value="entry.familiarity"
-          @input="(rating) => onRatingChange(rating, entry)"
-        />
-        <button
-          id="td-delete-button"
-          type="button"
-          @click="deleteVocab(entry.id)"
-          aria-label="delete"
-        >
-          <i class="fa fa-trash" aria-hidden="true"></i>
-        </button>
-      </td>
-    </tr>
-  </table>
-  -->
   <div>
      <div class="d-flex justify-content-between mb-2">
        <QuickAddVocabForm class="mr-2 text-left" />
@@ -49,7 +7,8 @@
      <vue-good-table
        :columns="columns"
        :rows="personalVocabEntries"
-       :pagination-options="{enabled:true}"
+       :pagination-options="paginationOptions"
+       :search-options="searchOptions"
      >
       <template slot="table-row" slot-scope="props">
         <div v-if="props.column.field == 'familiarity'" class="d-flex">
@@ -98,6 +57,16 @@
     },
     data() {
       return {
+        searchOptions: {
+          enabled: true,
+        },
+        paginationOptions: {
+          enabled: true,
+          perPage: 25,
+          perPageDropdown: [10, 25, 50, 100],
+          dropdownAllowAll: false,
+          mode: 'records',
+        },
         columns: [
           { label: 'Headword', field: 'headword' },
           { label: 'Gloss', field: 'gloss' },

--- a/static/src/js/app/index.js
+++ b/static/src/js/app/index.js
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import VueKeybindings from 'vue-keybindings';
 import VueFilterDateFormat from '@vuejs-community/vue-filter-date-format';
+import VueGoodTablePlugin from 'vue-good-table';
+import 'vue-good-table/dist/vue-good-table.css';
 
 import globalComponents from './components';
 import store from './store';
@@ -30,6 +32,7 @@ const load = (appId, appComponent, keyBindingsConfig, appProps) => {
     }
 
     Vue.use(VueFilterDateFormat);
+    Vue.use(VueGoodTablePlugin);
 
     /* eslint-disable no-new */
     new Vue({


### PR DESCRIPTION
This PR fixes slow render performance of the personal vocab when there are a lot of entries.

Changes:
- Added [vue-good-table](https://xaksis.github.io/vue-good-table/) component to render the personal vocab entries.
- Enabled [pagination](https://xaksis.github.io/vue-good-table/guide/configuration/pagination-options.html#enabled) and [searching](https://xaksis.github.io/vue-good-table/guide/configuration/search-options.html) of the entries. 

Notes:
- Since the API query returns quickly and is not currently a bottleneck, we're not paginating that yet. The `vue-good-table` component supports server-side pagination, so we can implement that when needed.

Example screenshot:

![hedera-vue-good-table-20210914](https://user-images.githubusercontent.com/1165361/133337451-b8a42657-9ef7-4933-8c52-6ab54dd0c953.png)
