### PR TITLE
Vocab list refactor

### DIFF
--- a/vocab_list/models.py
+++ b/vocab_list/models.py
@@ -119,7 +119,7 @@ class VocabularyList(AbstractVocabList):
 
 
 class PersonalVocabularyList(AbstractVocabList):
-
+    # TODO: this could be refacted to the abstract class, but VocabularyList defines it as "owner"
     user = models.ForeignKey(
         getattr(settings, "AUTH_USER_MODEL", "auth.User"),
         on_delete=models.CASCADE
@@ -211,6 +211,11 @@ class PersonalVocabularyListEntry(AbstractVocabListEntry):
     vocabulary_list = models.ForeignKey(
         PersonalVocabularyList, related_name="entries", on_delete=models.CASCADE)
     familiarity = models.IntegerField(null=True)
+    # 1. I don't recognise this word
+    # 2. I recognise this word but don't know what it means
+    # 3. I think I know what this word means
+    # 4. I definitely know what this word means but could forget soon
+    # 5. I know this word so well, I am unlikely to ever forget it
     node = models.ForeignKey(LatticeNode, null=True, blank=True, on_delete=models.SET_NULL)
 
     class Meta:

--- a/vocab_list/models.py
+++ b/vocab_list/models.py
@@ -8,7 +8,6 @@ from django_rq import job
 from iso639 import languages
 
 from lattices.models import LatticeNode, LemmaNode
-# from lattices.utils import make_lemma
 from lemmatized_text.models import LemmatizedText
 
 
@@ -24,18 +23,74 @@ def strip_diacritics(s):
 
 
 @job("default", timeout=600)
-def link_vl_node(pk):
-    obj = VocabularyListEntry.objects.get(pk=pk)
+def link_vl_node(model, pk):
+    obj = model.objects.get(pk=pk)
     obj.link()
 
 
-@job("default", timeout=600)
-def link_pvl_node(pk):
-    obj = PersonalVocabularyListEntry.objects.get(pk=pk)
-    obj.link()
+def clean(headword, gloss):
+    """Expect a headword and gloss, i.e., two columns,
+    & additional columns will be ingnored."""
+    return (headword.strip().strip('"'), gloss.strip().strip('"'))
 
 
-class VocabularyList(models.Model):
+def parse_line(idx, line):
+    try:
+        columns = line.decode("utf-8").strip().split("\t")
+    except UnicodeDecodeError:
+        return ("Line " + str(idx), "Bad Data")
+    return clean(*columns)
+
+
+class AbstractVocabList(models.Model):
+    lang = models.CharField(max_length=3)  # ISO 639.2
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+    def display_name(self):
+        return languages.get(part3=self.lang).name
+
+    def _list_entry_already_exists(self, model, lines):
+        return [
+            p.headword
+            for p in model.objects.filter(
+                vocabulary_list=self,
+                headword__in=lines
+            )
+        ]
+
+    def create_entry(self, model, index, **kwargs):
+        return model(
+            **kwargs,
+            vocabulary_list=self,
+            _order=index
+        )
+
+    def create_entires(self, lines, already_exist, familiarity=None, personal=False):
+        entries = []
+        model = VocabularyListEntry if not personal else PersonalVocabularyListEntry
+        for idx, line in enumerate(lines):
+            if line[0] != "" and line[0] not in already_exist:
+                kwargs = {
+                    "headword": line[0],
+                    "gloss": line[1],
+                }
+                if personal:
+                    kwargs["familiarity"] = familiarity
+                entries.append(self.create_entry(model, idx, **kwargs))
+        return entries
+
+    def load_tab_delimited(self, fd, model, familiarity=None, personal=False):
+        lines = [parse_line(idx, line) for idx, line in enumerate(fd)]
+        already_exist = self._list_entry_already_exists(model, lines)
+        entries = self.create_entires(lines, already_exist, familiarity=familiarity, personal=personal)
+        return model.objects.bulk_create(entries)
+
+
+class VocabularyList(AbstractVocabList):
 
     # a NULL owner means a system-provided vocabulary list
     owner = models.ForeignKey(
@@ -46,48 +101,13 @@ class VocabularyList(models.Model):
     )
     title = models.CharField(max_length=255)
     description = models.TextField(blank=True)
-    lang = models.CharField(max_length=3)  # ISO 639.2
-
-    created = models.DateTimeField(auto_now_add=True)
-    updated = models.DateTimeField(auto_now=True)
 
     cloned_from = models.ForeignKey(
         "self", null=True, editable=False, on_delete=models.SET_NULL
     )
 
     def load_tab_delimited(self, fd):
-        def clean(headword, gloss, *args):
-            """Expect a headword and gloss, i.e., two columns,
-               & additional columns will be ingnored."""
-            return (headword.strip().strip('"'), gloss.strip().strip('"'))
-
-        def parse_line(idx, line):
-            try:
-                columns = line.decode("utf-8").strip().split("\t")
-            except UnicodeDecodeError:
-                return ("Line " + str(idx), "Bad Data")
-            return clean(*columns)
-
-        lines = [parse_line(idx, line) for idx, line in enumerate(fd)]
-
-        already_exist = [
-            p.headword
-            for p in VocabularyListEntry.objects.filter(
-                vocabulary_list=self,
-                headword__in=[line[0] for line in lines]
-            )
-        ]
-        entries = [
-            VocabularyListEntry(
-                vocabulary_list=self,
-                headword=line[0],
-                gloss=line[1],
-                _order=index
-            )
-            for index, line in enumerate(lines)
-            if line[0] != "" and line[0] not in already_exist
-        ]
-        return VocabularyListEntry.objects.bulk_create(entries)
+        return super().load_tab_delimited(fd, VocabularyListEntry)
 
     @property
     def link_status(self):
@@ -99,9 +119,6 @@ class VocabularyList(models.Model):
     def __str__(self):
         return self.title
 
-    def display_name(self):
-        return languages.get(part3=self.lang).name
-
     def data(self):
         return {
             "id": self.pk,
@@ -112,67 +129,12 @@ class VocabularyList(models.Model):
         }
 
 
-class VocabularyListEntry(models.Model):
-
-    vocabulary_list = models.ForeignKey(
-        VocabularyList, related_name="entries", on_delete=models.CASCADE)
-
-    headword = models.CharField(max_length=255)
-    gloss = models.TextField(blank=True)
-
-    node = models.ForeignKey(
-        LatticeNode, related_name="vocabulary_entries", null=True, on_delete=models.SET_NULL)
-
-    link_job_id = models.CharField(max_length=250, blank=True)
-    link_job_started = models.DateTimeField(null=True)
-    link_job_ended = models.DateTimeField(null=True)
-
-    created = models.DateTimeField(auto_now_add=True)
-    updated = models.DateTimeField(auto_now=True)
-
-    def link_job(self):
-        j = link_vl_node.delay(self.pk)
-        self.link_job_id = j.id
-        self.link_job_started = timezone.now()
-        self.save()
-
-    def link(self):
-        first = strip_diacritics(self.headword.split()[0].strip(","))
-        lemma_node = LemmaNode.objects.filter(lemma=first).first()
-        if lemma_node is None:
-            for lemma_node in LemmaNode.objects.filter(lemma__istartswith=first):
-                if lemma_node.node.children.exists():
-                    break
-        if lemma_node:
-            self.node = lemma_node.node
-        self.link_job_ended = timezone.now()
-        self.save()
-
-    class Meta:
-        verbose_name = "vocabulary list entry"
-        verbose_name_plural = "vocabulary list entries"
-        order_with_respect_to = "vocabulary_list"
-        unique_together = ("vocabulary_list", "headword")
-
-    def data(self):
-        return dict(
-            id=self.pk,
-            headword=self.headword,
-            gloss=self.gloss,
-            node=self.node.pk if self.node is not None else None
-        )
-
-
-class PersonalVocabularyList(models.Model):
+class PersonalVocabularyList(AbstractVocabList):
 
     user = models.ForeignKey(
         getattr(settings, "AUTH_USER_MODEL", "auth.User"),
         on_delete=models.CASCADE
     )
-    lang = models.CharField(max_length=3)  # ISO 639.2
-
-    created = models.DateTimeField(auto_now_add=True)
-    updated = models.DateTimeField(auto_now=True)
 
     class Meta:
         verbose_name = "personal vocabulary list"
@@ -181,39 +143,12 @@ class PersonalVocabularyList(models.Model):
     def __str__(self):
         return f"{self.user} personal {self.lang} vocab list"
 
-    def display_name(self):
-        return languages.get(part3=self.lang).name
-
     def node_familiarity(self):
         return 10
 
     def load_tab_delimited(self, fd, familiarity):
-        def clean(headword, gloss):
-            return (headword.strip().strip('"'), gloss.strip().strip('"'))
-
-        lines = [
-            clean(*line.decode("utf-8").strip().split("\t"))
-            for line in fd
-        ]
-        already_exist = [
-            p.headword
-            for p in PersonalVocabularyListEntry.objects.filter(
-                vocabulary_list=self,
-                headword__in=[line[0] for line in lines]
-            )
-        ]
-        entries = [
-            PersonalVocabularyListEntry(
-                vocabulary_list=self,
-                familiarity=familiarity,
-                headword=line[0],
-                gloss=line[1],
-                _order=index
-            )
-            for index, line in enumerate(lines)
-            if line[0] != "" and line[0] not in already_exist
-        ]
-        return PersonalVocabularyListEntry.objects.bulk_create(entries)
+        return super().load_tab_delimited(
+            fd, PersonalVocabularyListEntry, familiarity=familiarity, personal=True)
 
     def data(self):
         stats = {}
@@ -226,45 +161,17 @@ class PersonalVocabularyList(models.Model):
         }
 
 
-class PersonalVocabularyListEntry(models.Model):
-
-    vocabulary_list = models.ForeignKey(
-        PersonalVocabularyList,
-        related_name="entries",
-        on_delete=models.CASCADE
-    )
-
+class AbstractVocabListEntry(models.Model):
     headword = models.CharField(max_length=255)
     gloss = models.TextField(blank=True)
-
-    # 1. I don't recognise this word
-    # 2. I recognise this word but don't know what it means
-    # 3. I think I know what this word means
-    # 4. I definitely know what this word means but could forget soon
-    # 5. I know this word so well, I am unlikely to ever forget it
-
-    familiarity = models.IntegerField(null=True)
-
-    node = models.ForeignKey(LatticeNode, null=True, blank=True, on_delete=models.SET_NULL)
-
     link_job_id = models.CharField(max_length=250, blank=True)
     link_job_started = models.DateTimeField(null=True)
     link_job_ended = models.DateTimeField(null=True)
-
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
     class Meta:
-        verbose_name = "personal vocabulary list entry"
-        verbose_name_plural = "personal vocabulary list entries"
-        order_with_respect_to = "vocabulary_list"
-        unique_together = ("vocabulary_list", "headword")
-
-    def link_job(self):
-        j = link_pvl_node.delay(self.pk)
-        self.link_job_id = j.id
-        self.link_job_started = timezone.now()
-        self.save()
+        abstract = True
 
     def link(self):
         first = strip_diacritics(self.headword.split()[0].strip(","))
@@ -278,14 +185,57 @@ class PersonalVocabularyListEntry(models.Model):
         self.link_job_ended = timezone.now()
         self.save()
 
+    def link_job(self, model):
+        j = link_vl_node.delay(model, self.pk)
+        self.link_job_id = j.id
+        self.link_job_started = timezone.now()
+        self.save()
+
+    def data(self, **kwargs):
+        return {
+            "id": self.pk,
+            "headword": self.headword,
+            "gloss": self.gloss,
+            **kwargs
+        }
+
+
+class VocabularyListEntry(AbstractVocabListEntry):
+    vocabulary_list = models.ForeignKey(
+        VocabularyList, related_name="entries", on_delete=models.CASCADE)
+    node = models.ForeignKey(
+        LatticeNode, related_name="vocabulary_entries", null=True, on_delete=models.SET_NULL)
+
+    class Meta:
+        verbose_name = "vocabulary list entry"
+        verbose_name_plural = "vocabulary list entries"
+        order_with_respect_to = "vocabulary_list"
+        unique_together = ("vocabulary_list", "headword")
+
+    def link_job(self):
+        return super().link_job(VocabularyListEntry)
+
     def data(self):
-        return dict(
-            id=self.pk,
-            headword=self.headword,
-            gloss=self.gloss,
-            familiarity=self.familiarity,
-            node=self.node_id if self.node_id is not None else None,
-        )
+        return super().data(node=self.node_id)
+
+
+class PersonalVocabularyListEntry(AbstractVocabListEntry):
+    vocabulary_list = models.ForeignKey(
+        PersonalVocabularyList, related_name="entries", on_delete=models.CASCADE)
+    familiarity = models.IntegerField(null=True)
+    node = models.ForeignKey(LatticeNode, null=True, blank=True, on_delete=models.SET_NULL)
+
+    class Meta:
+        verbose_name = "personal vocabulary list entry"
+        verbose_name_plural = "personal vocabulary list entries"
+        order_with_respect_to = "vocabulary_list"
+        unique_together = ("vocabulary_list", "headword")
+
+    def link_job(self):
+        return super().link_job(PersonalVocabularyListEntry)
+
+    def data(self):
+        return super().data(familiarity=self.familiarity, node=self.node_id)
 
     def familiarity_range(self):
         # hack for template iteration

--- a/vocab_list/tests.py
+++ b/vocab_list/tests.py
@@ -49,10 +49,13 @@ class VocabularyListAndEntryTests(TestCase):
         }
         self.assertEqual(self.vocab_list.data(), expected_data)
 
+    def test_display_name(self):
+        self.assertEqual(self.vocab_list.display_name(), "Latin")
+
     def test_entry_data(self):
         entry = VocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
         expected_data = {
-            "id": 5,
+            "id": 9,
             "headword": "melon",
             "gloss": "armor",
             "node": None
@@ -111,10 +114,13 @@ class PersonalVocabularyListAndEntryTests(TestCase):
         }
         self.assertEqual(self.vocab_list.data(), expected_data)
 
+    def test_display_name(self):
+        self.assertEqual(self.vocab_list.display_name(), "Latin")
+
     def test_entry_data(self):
         entry = PersonalVocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
         expected_data = {
-            "id": 5,
+            "id": 9,
             "headword": "melon",
             "gloss": "armor",
             "familiarity": 2,

--- a/vocab_list/tests.py
+++ b/vocab_list/tests.py
@@ -25,6 +25,16 @@ def create_user(username, email, password):
     return get_user_model().objects.create_user(username, email=email, password=password)
 
 
+def check_entries(expected_entries, actual_entries):
+    bool_list = [
+        True
+        for expected_entry in expected_entries
+        for actual_entry in actual_entries
+        if actual_entry.items() >= expected_entry.items()
+    ]
+    return len(bool_list) == len(expected_entries)
+
+
 class VocabularyListAndEntryTests(TestCase):
 
     def setUp(self):
@@ -41,13 +51,12 @@ class VocabularyListAndEntryTests(TestCase):
 
     def test_data(self):
         expected_data = {
-            "id": 1,
             "title": "Foo",
             "description": "Bar",
             "link_status": 0.0,
             "owner": None
         }
-        self.assertEqual(self.vocab_list.data(), expected_data)
+        self.assertGreaterEqual(self.vocab_list.data().items(), expected_data.items())
 
     def test_display_name(self):
         self.assertEqual(self.vocab_list.display_name(), "Latin")
@@ -55,12 +64,11 @@ class VocabularyListAndEntryTests(TestCase):
     def test_entry_data(self):
         entry = VocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
         expected_data = {
-            "id": 9,
             "headword": "melon",
             "gloss": "armor",
             "node": None
         }
-        self.assertEqual(entry.data(), expected_data)
+        self.assertGreaterEqual(entry.data().items(), expected_data.items())
 
 
 class PersonalVocabularyListAndEntryTests(TestCase):
@@ -78,41 +86,29 @@ class PersonalVocabularyListAndEntryTests(TestCase):
         self.assertEqual(self.vocab_list.entries.count(), 4)
 
     def test_data(self):
-        expected_data = {
-            "entries": [
-                {
-                    "id": 3,
-                    "headword": "bin",
-                    "gloss": "bash",
-                    "familiarity": 2,
-                    "node": None
-                },
-                {
-                    "id": 2,
-                    "headword": "foo",
-                    "gloss": "bar",
-                    "familiarity": 2,
-                    "node": None
-                },
-                {
-                    "id": 4,
-                    "headword": "hello",
-                    "gloss": "world",
-                    "familiarity": 2,
-                    "node": None
-                },
-                {
-                    "id": 1,
-                    "headword": "melon",
-                    "gloss": "armor",
-                    "familiarity": 2,
-                    "node": None
-                }
-            ],
-            "statsByText": {},
-            "id": 1
-        }
-        self.assertEqual(self.vocab_list.data(), expected_data)
+        expected_entries = [
+            {
+                "headword": "bin",
+                "gloss": "bash",
+                "familiarity": 2,
+            },
+            {
+                "headword": "foo",
+                "gloss": "bar",
+                "familiarity": 2,
+            },
+            {
+                "headword": "hello",
+                "gloss": "world",
+                "familiarity": 2,
+            },
+            {
+                "headword": "melon",
+                "gloss": "armor",
+                "familiarity": 2,
+            }
+        ]
+        self.assertTrue(check_entries(expected_entries, self.vocab_list.data()["entries"]))
 
     def test_display_name(self):
         self.assertEqual(self.vocab_list.display_name(), "Latin")
@@ -120,10 +116,9 @@ class PersonalVocabularyListAndEntryTests(TestCase):
     def test_entry_data(self):
         entry = PersonalVocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
         expected_data = {
-            "id": 9,
             "headword": "melon",
             "gloss": "armor",
             "familiarity": 2,
             "node": None
         }
-        self.assertEqual(entry.data(), expected_data)
+        self.assertGreaterEqual(entry.data().items(), expected_data.items())

--- a/vocab_list/tests.py
+++ b/vocab_list/tests.py
@@ -1,0 +1,123 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from django.contrib.auth import get_user_model
+
+from .models import (
+    PersonalVocabularyList,
+    PersonalVocabularyListEntry,
+    VocabularyList,
+    VocabularyListEntry
+)
+
+
+vocab_list_tsv_content = b"""\
+melon\tarmor
+foo\tbar
+bin\tbash
+hello\tworld"""
+
+
+EXAMPLE_VOCAB_LIST_TSV = SimpleUploadedFile("test.tsv", vocab_list_tsv_content)
+
+
+def create_user(username, email, password):
+    return get_user_model().objects.create_user(username, email=email, password=password)
+
+
+class VocabularyListAndEntryTests(TestCase):
+
+    def setUp(self):
+        self.vocab_list = VocabularyList(
+            lang="lat",
+            title="Foo",
+            description="Bar"
+        )
+        self.vocab_list.save()
+        self.vocab_list.load_tab_delimited(EXAMPLE_VOCAB_LIST_TSV)
+
+    def test_load_tab_delimited(self):
+        self.assertEqual(self.vocab_list.entries.count(), 4)
+
+    def test_data(self):
+        expected_data = {
+            "id": 1,
+            "title": "Foo",
+            "description": "Bar",
+            "link_status": 0.0,
+            "owner": None
+        }
+        self.assertEqual(self.vocab_list.data(), expected_data)
+
+    def test_entry_data(self):
+        entry = VocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
+        expected_data = {
+            "id": 5,
+            "headword": "melon",
+            "gloss": "armor",
+            "node": None
+        }
+        self.assertEqual(entry.data(), expected_data)
+
+
+class PersonalVocabularyListAndEntryTests(TestCase):
+
+    def setUp(self):
+        self.user = create_user("okieDokey", "smokey@fake.com", "password")
+        self.vocab_list = PersonalVocabularyList(
+            lang="lat",
+            user=self.user
+        )
+        self.vocab_list.save()
+        self.vocab_list.load_tab_delimited(EXAMPLE_VOCAB_LIST_TSV, 2)
+
+    def test_load_tab_delimited(self):
+        self.assertEqual(self.vocab_list.entries.count(), 4)
+
+    def test_data(self):
+        expected_data = {
+            "entries": [
+                {
+                    "id": 3,
+                    "headword": "bin",
+                    "gloss": "bash",
+                    "familiarity": 2,
+                    "node": None
+                },
+                {
+                    "id": 2,
+                    "headword": "foo",
+                    "gloss": "bar",
+                    "familiarity": 2,
+                    "node": None
+                },
+                {
+                    "id": 4,
+                    "headword": "hello",
+                    "gloss": "world",
+                    "familiarity": 2,
+                    "node": None
+                },
+                {
+                    "id": 1,
+                    "headword": "melon",
+                    "gloss": "armor",
+                    "familiarity": 2,
+                    "node": None
+                }
+            ],
+            "statsByText": {},
+            "id": 1
+        }
+        self.assertEqual(self.vocab_list.data(), expected_data)
+
+    def test_entry_data(self):
+        entry = PersonalVocabularyListEntry.objects.filter(vocabulary_list=self.vocab_list).first()
+        expected_data = {
+            "id": 5,
+            "headword": "melon",
+            "gloss": "armor",
+            "familiarity": 2,
+            "node": None
+        }
+        self.assertEqual(entry.data(), expected_data)


### PR DESCRIPTION
This PR resolves [ATGU-3255](https://jira.huit.harvard.edu/browse/ATGU-3255) by:

- Adding the `AbstractVocabList` and `AbstractVocabListEntry` abstract classes to refactor repeated fields and methods
- Adding tests to gauge the safety of the refactoring/absracting 
- Adding docstrings to functions/methods that could use some documentation

## Notes

- The refactoring/abstraction definitely helps this module to adhere to DRY principals, but I wonder if it makes it more or less comprehensible? That's an open question for me