### PR TITLE
Use multistage build to help with local dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,17 @@
+__pycache__
 .docker-data
+.dockerignore
+.editorconfig
+.eslintignore
+.git
+.github
+.gitignore
+.pre-commit-config.yaml
+.nvmrc
+.venv
+.vscode
+Dockerfile
 node_modules
+setup.cfg
+webpack-stats
+ux

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.7
+FROM python:3.7 AS prod
 
-# Upgrade pip 
+# Upgrade pip
 RUN pip install --upgrade pip
 
 # Create app working directory
@@ -27,8 +27,15 @@ RUN npm i && \
 # Copy app files
 COPY . /app
 
-# Build webpack assets 
+# Build webpack assets
 RUN npm run build
 
 # Use port 8000 for django server or 8080 for webpack dev server
 EXPOSE 8000 8080
+
+FROM prod AS dev
+
+# Install python dev dependencies
+COPY ./hedera/requirements/dev.txt /app/
+RUN pip install -r dev.txt && \
+    rm dev.txt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM hedera-django:latest
+
+# Install python dev dependencies
+COPY ./hedera/requirements/dev.txt /app/
+RUN pip install -r dev.txt && \
+    rm dev.txt

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,0 @@
-FROM hedera-django:latest
-
-# Install python dev dependencies
-COPY ./hedera/requirements/dev.txt /app/
-RUN pip install -r dev.txt && \
-    rm dev.txt

--- a/README.md
+++ b/README.md
@@ -13,14 +13,19 @@ Hedera is an application for viewing texts in different languages such that:
 
 Before running for the first time (or any time for that matter):
 
+```sh
+# first, build the prod django image
+docker compose build npm
+# next, build the dev images
+docker compose build
 ```
-docker-compose build
-```
+
+* **Details:** Local development uses two images, one built with the `Dockerfile` (this is the production image), and a derivative image built with the `Dockerfile.dev` (this is the development image; it simply adds dev dependencies as an extra layer to the prod image). The `npm` docker compose service uses the production image, and the `django` and `worker` services use the development image.
 
 To run the app:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 When are you are finished, simply hit `ctrl-c` and the containers will shutdown.
@@ -28,14 +33,14 @@ When are you are finished, simply hit `ctrl-c` and the containers will shutdown.
 On initial running, you might want do run the following in another terminal:
 
 ```
-docker-compose run django python manage.py create_cms
+docker compose run --rm django python manage.py create_cms
 ```
 
 To import lattice data:
 
 ```
-docker-compose run django python manage.py shell -c "import load_ivy_lattice"
-docker-compose run django python manage.py shell -c "import logeion_load"
+docker compose run --rm django python manage.py shell -c "import load_ivy_lattice"
+docker compose run --rm django python manage.py shell -c "import logeion_load"
 ```
 
 (Optional) Chinese lattice data:
@@ -43,10 +48,10 @@ docker-compose run django python manage.py shell -c "import logeion_load"
 **Caution**: _This can take more than one hour._
 
 ```sh
-docker-compose run django python manage.py shell -c "import load_chinese_lattice"
+docker compose run --rm django python manage.py shell -c "import load_chinese_lattice"
 ```
 
-#### Good to know's and Gotcha's
+#### **Good to know's and Gotcha's**
 
 Steps to add a new python package:
 Prequisite - Install pip-compile into your virtual env via this command `python -m pip install pip-tools`. [Documentation here](https://github.com/jazzband/pip-tools)
@@ -55,13 +60,16 @@ Prequisite - Install pip-compile into your virtual env via this command `python 
 3. Run:
     ```
     pip-compile hedera/requirements/base.in --output-file=- > hedera/requirements/base.txt
-    docker-compose exec django pip install <package>
-    docker-compose exec worker pip install <package>
+    docker compose exec django pip install <package>
+    docker compose exec worker pip install <package>
     ```
-    Note: Alternatively we could also rebuild the image for django and worker after running `pip-compile hedera/requirements/base.in --output-file=- > hedera/requirements/base.txt` via these commands:
-    ```
-    docker-compose build django
-    docker-compose build worker
+    Note: Alternatively we could also rebuild the images for npm, django and worker after running `pip-compile hedera/requirements/base.in --output-file=- > hedera/requirements/base.txt` via these commands:
+    ```sh
+    # rebuild the base/prod image
+    docker compose build npm
+    # rebuild the dev images
+    docker compose build django
+    docker compose build worker
     ```
 Note/TODO: We will have to update how we run the exec commands with root in favor of a designated user. Running the above exec commands will cause the following warning flag:
 ```diff
@@ -70,10 +78,13 @@ Note/TODO: We will have to update how we run the exec commands with root in favo
 
 If you'd like to remove all existing images and start fresh:
 
-```
-docker-compose down --rmi all
-docker-compose build
-docker-compose up
+```sh
+docker compose down --rmi all
+# first, build the prod django image
+docker compose build npm
+# next, build the dev images
+docker compose build
+docker compose up
 ```
 
 If you've run a lot of containers and you'd like to clean them up so that your `docker compose` command output isn't endless:
@@ -180,7 +191,7 @@ This project uses `isort` for import sorting, `flake8` for Python linting, and v
 
 #### Pre-commit
 
-To make developement more streamlined we have implemented a pre-commit package manager to manage pre-commit hooks for python and javascript
+To make developement more streamlined we have implemented a pre-commit package manager to manage pre-commit hooks for python and javascript.
 - Install [Pre-commit](https://pre-commit.com/)
 Note: the installation guide covers different install methods
 - you will then need to run the following command in the root of the project
@@ -199,14 +210,14 @@ Every so often, it may be requested that the dev DB be "reset." Meaning, tables 
 # Run the custom management command to delete all of the relevant data.
 # The --no_input flag answers 'yes' to all prompts asking if you'd like to delete data.
 # Run without --no_input if you'd like to step through the process interatctively.
-$ docker-compose exec django python manage.py reset_db --no_input
+$ docker compose exec django python manage.py reset_db --no_input
 
 # Run commands to reload the data
-$ docker-compose exec django python manage.py shell -c "import load_ivy_wonky_words"
-$ docker-compose exec django python manage.py shell -c "import load_ivy_lattice"
-$ docker-compose exec django python manage.py shell -c "import logeion_load"
-$ docker-compose exec django python manage.py shell -c "import load_clancy_lattice"
-$ docker-compose exec django python manage.py shell -c "import load_chinese_lattice"
+$ docker compose exec django python manage.py shell -c "import load_ivy_wonky_words"
+$ docker compose exec django python manage.py shell -c "import load_ivy_lattice"
+$ docker compose exec django python manage.py shell -c "import logeion_load"
+$ docker compose exec django python manage.py shell -c "import load_clancy_lattice"
+$ docker compose exec django python manage.py shell -c "import load_chinese_lattice"
 ```
 
 ## Adding a new language

--- a/README.md
+++ b/README.md
@@ -14,13 +14,10 @@ Hedera is an application for viewing texts in different languages such that:
 Before running for the first time (or any time for that matter):
 
 ```sh
-# first, build the prod django image
-docker compose build npm
-# next, build the dev images
 docker compose build
 ```
 
-* **Details:** Local development uses two images, one built with the `Dockerfile` (this is the production image), and a derivative image built with the `Dockerfile.dev` (this is the development image; it simply adds dev dependencies as an extra layer to the prod image). The `npm` docker compose service uses the production image, and the `django` and `worker` services use the development image.
+* **Details:** Local development uses the `dev` stage of the `Dockerfile`, which adds development dependencies to the `prod` stage. The `npm` docker compose service uses the `prod` stage, and the `django` and `worker` services use the `dev` stage.
 
 To run the app:
 
@@ -63,11 +60,8 @@ Prequisite - Install pip-compile into your virtual env via this command `python 
     docker compose exec django pip install <package>
     docker compose exec worker pip install <package>
     ```
-    Note: Alternatively we could also rebuild the images for npm, django and worker after running `pip-compile hedera/requirements/base.in --output-file=- > hedera/requirements/base.txt` via these commands:
+    Note: Alternatively we could also rebuild the images for the `django` and `worker` services after running `pip-compile hedera/requirements/base.in --output-file=- > hedera/requirements/base.txt` via these commands:
     ```sh
-    # rebuild the base/prod image
-    docker compose build npm
-    # rebuild the dev images
     docker compose build django
     docker compose build worker
     ```
@@ -80,9 +74,6 @@ If you'd like to remove all existing images and start fresh:
 
 ```sh
 docker compose down --rmi all
-# first, build the prod django image
-docker compose build npm
-# next, build the dev images
 docker compose build
 docker compose up
 ```
@@ -191,7 +182,7 @@ This project uses `isort` for import sorting, `flake8` for Python linting, and v
 
 #### Pre-commit
 
-To make developement more streamlined we have implemented a pre-commit package manager to manage pre-commit hooks for python and javascript.
+To make development more streamlined we have implemented a pre-commit package manager to manage pre-commit hooks for python and javascript.
 - Install [Pre-commit](https://pre-commit.com/)
 Note: the installation guide covers different install methods
 - you will then need to run the following command in the root of the project

--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+    django:
+        image: hedera-django-dev
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: dev
+        working_dir: /app
+        volumes:
+            # explicitly mount local directories and files that have
+            # source code which could change; we _don't_ want to mount
+            # the whole project directory, because that would include
+            # node_modules, which may have different bindings on the
+            # host vs container
+            - ./cms/:/app/cms
+            - ./fixtures/:/app/fixtures
+            - ./groups/:/app/groups
+            - ./hedera/:/app/hedera
+            - ./import-data/:/app/import-data
+            - ./lattices/:/app/lattices
+            - ./lemmatization/:/app/lemmatization
+            - ./lemmatized_text/:/app/lemmatized_text
+            - ./lti/:/app/lti
+            - ./pdfservice/:/app/pdfservice
+            - ./static/src/:/app/static/src
+            - ./vocab_list/:/app/vocab_list
+            - ./manage.py/:/app/manage.py
+        depends_on:
+            - postgres
+            - redis
+        environment:
+            RQ_ASYNC: 1
+            DATABASE_URL: postgres://hedera:hedera@postgres/hedera
+            REDIS_URL: redis://redis:6379
+            PYTHONFAULTHANDLER: 1
+            PYTHONUNBUFFERED: 1
+            PYTHONDONTWRITEBYTECODE: 1
+        networks:
+            - localdev
+        stop_signal: SIGINT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,78 +39,20 @@ services:
             - "8080:8080"
         command: /bin/sh -c 'npm i && npm start'
     django:
-        image: hedera-django-dev
-        build:
-            context: .
-            dockerfile: Dockerfile
-            target: dev
+        extends:
+            file: docker-compose-common.yml
+            service: django
         container_name: hedera-django
-        working_dir: /app
-        volumes:
-            - ./cms/:/app/cms
-            - ./fixtures/:/app/fixtures
-            - ./groups/:/app/groups
-            - ./hedera/:/app/hedera
-            - ./import-data/:/app/import-data
-            - ./lattices/:/app/lattices
-            - ./lemmatization/:/app/lemmatization
-            - ./lemmatized_text/:/app/lemmatized_text
-            - ./lti/:/app/lti
-            - ./pdfservice/:/app/pdfservice
-            - ./static/src/:/app/static/src
-            - ./vocab_list/:/app/vocab_list
-            - ./manage.py/:/app/manage.py
         ports:
             - "5678:5678"  # default for debugpy
             - "8000:8000"
-        depends_on:
-            - postgres
-            - redis
-        environment:
-            RQ_ASYNC: 1
-            DATABASE_URL: postgres://hedera:hedera@postgres/hedera
-            REDIS_URL: redis://redis:6379
-            PYTHONFAULTHANDLER: 1
-            PYTHONUNBUFFERED: 1
-            PYTHONDONTWRITEBYTECODE: 1
-        networks:
-            - localdev
         command: /bin/sh -c 'trap - SIGINT; while ! nc -z postgres 5432; do sleep 1; done; python manage.py migrate & python manage.py loaddata sites & exec python manage.py runserver 0.0.0.0:8000'
-        stop_signal: SIGINT
     worker:
         image: hedera-django-dev
-        build:
-            context: .
-            dockerfile: Dockerfile
-            target: dev
+        extends:
+            file: docker-compose-common.yml
+            service: django
         container_name: hedera-worker
-        working_dir: /app
         ports:
             - "5679:5678"
-        volumes:
-            - ./cms/:/app/cms
-            - ./fixtures/:/app/fixtures
-            - ./groups/:/app/groups
-            - ./hedera/:/app/hedera
-            - ./import-data/:/app/import-data
-            - ./lattices/:/app/lattices
-            - ./lemmatization/:/app/lemmatization
-            - ./lemmatized_text/:/app/lemmatized_text
-            - ./lti/:/app/lti
-            - ./pdfservice/:/app/pdfservice
-            - ./static/src/:/app/static/src
-            - ./vocab_list/:/app/vocab_list
-            - ./manage.py/:/app/manage.py
-        depends_on:
-            - postgres
-            - redis
-        environment:
-            RQ_ASYNC: 1
-            DATABASE_URL: postgres://hedera:hedera@postgres/hedera
-            REDIS_URL: redis://redis:6379
-            PYTHONDONTWRITEBYTECODE: 1
-            PYTHONUNBUFFERED: 1
-        networks:
-            - localdev
         command: /bin/sh -c 'while ! nc -z postgres 5432; do sleep 1; done; while ! nc -z redis 6379; do sleep 1; done; exec python manage.py rqworker ${RQ_QUEUES:-default}'
-        stop_signal: SIGINT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         networks:
             - localdev
     npm:
-        image: postgres-django
+        image: hedera-django
         build:
             context: .
             dockerfile: Dockerfile
@@ -40,10 +40,10 @@ services:
             - "8080:8080"
         command: /bin/sh -c 'npm i && npm start'
     django:
-        image: postgres-django
+        image: hedera-django-dev
         build:
             context: .
-            dockerfile: Dockerfile
+            dockerfile: Dockerfile.dev
         container_name: hedera-django
         working_dir: /app
         volumes:
@@ -66,7 +66,7 @@ services:
         command: /bin/sh -c 'trap - SIGINT; while ! nc -z postgres 5432; do sleep 1; done; python manage.py migrate & python manage.py loaddata sites & exec python manage.py runserver 0.0.0.0:8000'
         stop_signal: SIGINT
     worker:
-        image: postgres-django
+        image: hedera-django-dev
         container_name: hedera-worker
         working_dir: /app
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,8 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
+            target: prod
         container_name: hedera-npm
-        volumes:
-            - ./:/app
         working_dir: /app
         networks:
             - localdev
@@ -43,11 +42,24 @@ services:
         image: hedera-django-dev
         build:
             context: .
-            dockerfile: Dockerfile.dev
+            dockerfile: Dockerfile
+            target: dev
         container_name: hedera-django
         working_dir: /app
         volumes:
-            - ./:/app
+            - ./cms/:/app/cms
+            - ./fixtures/:/app/fixtures
+            - ./groups/:/app/groups
+            - ./hedera/:/app/hedera
+            - ./import-data/:/app/import-data
+            - ./lattices/:/app/lattices
+            - ./lemmatization/:/app/lemmatization
+            - ./lemmatized_text/:/app/lemmatized_text
+            - ./lti/:/app/lti
+            - ./pdfservice/:/app/pdfservice
+            - ./static/src/:/app/static/src
+            - ./vocab_list/:/app/vocab_list
+            - ./manage.py/:/app/manage.py
         ports:
             - "5678:5678"  # default for debugpy
             - "8000:8000"
@@ -67,12 +79,28 @@ services:
         stop_signal: SIGINT
     worker:
         image: hedera-django-dev
+        build:
+            context: .
+            dockerfile: Dockerfile
+            target: dev
         container_name: hedera-worker
         working_dir: /app
         ports:
             - "5679:5678"
         volumes:
-            - ./:/app
+            - ./cms/:/app/cms
+            - ./fixtures/:/app/fixtures
+            - ./groups/:/app/groups
+            - ./hedera/:/app/hedera
+            - ./import-data/:/app/import-data
+            - ./lattices/:/app/lattices
+            - ./lemmatization/:/app/lemmatization
+            - ./lemmatized_text/:/app/lemmatized_text
+            - ./lti/:/app/lti
+            - ./pdfservice/:/app/pdfservice
+            - ./static/src/:/app/static/src
+            - ./vocab_list/:/app/vocab_list
+            - ./manage.py/:/app/manage.py
         depends_on:
             - postgres
             - redis


### PR DESCRIPTION
This is a PR to spark some discussion. 

For easier debugging in local development, one approach is to ~use a dev Docker image that includes dev requirements~ make use of a multistage build, where dev requirements are extra layers on top of the production image.

Pros:
- prod image can also be run locally (e.g. for `npm` service)
- dev image "tests" prod image by inheriting from it

Cons:
- when running prod image, need to target the `prod` build stage explicitly to avoid including `dev` layers.