### PR TITLE
Run python unit tests in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .docker-data
 node_modules
+.venv
+.vscode
+__pycache__

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,34 @@ jobs:
     name: Running unit tests
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_DB: hedera
+          POSTGRES_USER: hedera
+          POSTGRES_PASSWORD: hedera
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
+
     steps:
         - uses: actions/checkout@v2
 
@@ -73,4 +101,4 @@ jobs:
 
         - name: Run tests
           run: |
-            python manage.py test
+            DATABASE_URL=postgres://hedera:hedera@localhost/hedera python manage.py test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,9 @@ jobs:
 
         - name: Install Python Dependences
           run: |
-            pip install -r hedera/requirements/base.txt && pip install -r hedera/requirements/dev.txt
+            pip install wheel && \
+            pip install -r hedera/requirements/base.txt && \
+            pip install -r hedera/requirements/dev.txt
 
         - name: Run tests
           run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
           uses: actions/setup-python@v2
           with:
             python-version: 3.7
-        
+
         - uses: actions/setup-node@v2
           with:
             node-version: '14'
@@ -43,3 +43,32 @@ jobs:
 
         - name: Lint JavaScript
           run: npm run lint
+
+  tests:
+    name: Running unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+        - uses: actions/checkout@v2
+
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.7
+
+        - name: Setup Cache
+          id: cache
+          uses: actions/cache@v2
+          with:
+            path: ~/.cache/pip
+            key: ${{ runner.os }}-pip-${{ hashFiles('**/**/requirements/dev.txt' ) }}
+            restore-keys: |
+              ${{ runner.os }}-pip-
+
+        - name: Install Python Dependences
+          run: |
+            pip install -r hedera/requirements/base.txt && pip install -r hedera/requirements/dev.txt
+
+        - name: Run tests
+          run: |
+            python manage.py test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,5 +100,6 @@ jobs:
             pip install -r hedera/requirements/dev.txt
 
         - name: Run tests
-          run: |
-            DATABASE_URL=postgres://hedera:hedera@localhost/hedera python manage.py test
+          env:
+            DJANGO_SETTINGS_MODULE: hedera.test_settings
+          run: python manage.py test

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cert.pem
 key.pem
 .docker-data
 coverage
+.venv

--- a/README.md
+++ b/README.md
@@ -172,11 +172,35 @@ docker run --publish 9000:9000 --env X_API_KEY=test-secret eldarioninc/pdf-servi
 
 ## Contributing Guidelines
 
+### Tests
+
+Unit tests depend on:
+* a connection to a postgres DB; this is due to limitations in the `django-lti-provider` package; see `test_settings.py`), and
+* a connection to redis (`django-rq` requires a redis connection, with no simply way to mock it for tests).
+
+Here's one way to run them, using the containerized app, which is already configured to look for the required support services on the docker container network:
+
+```
+docker compose up -d postgres redis
+# make sure postgres and redis are available, then run:
+docker compose run --rm --no-deps -e DJANGO_SETTINGS_MODULE=hedera.test_settings django python manage.py test
+```
+
+You can also run them locally (i.e. not in a container) if you have the appropriate python environment configured. For instance:
+
+```
+docker compose up -d postgres redis
+# make sure postgres and redis are available, then run:
+DJANGO_SETTINGS_MODULE=hedera.test_settings python manage.py test
+```
+
 ### Linting
 
 This project uses `isort` for import sorting, `flake8` for Python linting, and various `eslint plugins` for Javascript linting.
 
 ### Passing Builds via Github
+
+The GitHub Actions workflow .github/workflows/ci.yaml runs the unit tests and various code quality checks.
 
 #### Pre-commit
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
         restart: unless-stopped
         networks:
             - localdev
+        ports:
+            - "6379:6379"
+
     npm:
         image: postgres-django
         build:

--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -35,7 +35,7 @@ except ValueError:
 
 
 DATABASES = {
-    "default": dj_database_url.config(default="postgres://localhost/hedera")
+    "default": dj_database_url.config(default="postgres://hedera:hedera@localhost/hedera")
 }
 
 CSRF_TRUSTED_ORIGINS = ["canvas.harvard.edu"]

--- a/hedera/test_settings.py
+++ b/hedera/test_settings.py
@@ -1,0 +1,52 @@
+from webpack_loader.loader import WebpackLoader
+
+from .settings import *  # noqa: F401, F403
+
+
+# do not use workers or cache for RQ
+RQ_ASYNC = False
+
+
+# We need to fake webpack's stats file so that django-webpack-loader has what it needs
+# to render templates. See https://github.com/django-webpack/django-webpack-loader#usage-in-tests.
+class TestingWebpackLoader(WebpackLoader):
+    """See https://github.com/django-webpack/django-webpack-loader/issues/187#issuecomment-901449290"""
+
+    def get_bundle(self, bundle_name):
+        """
+        Effectively mocks out `render_bundle` template tag.
+
+        Return a non-existent JS bundle for each one requested.
+
+        Django webpack loader expects a bundle to exist for each one
+        that is requested via the 'render_bundle' template tag. Since we
+        don't want to store generated bundles in our repo, we need to
+        override this so that the template tags will still resolve to
+        something when we're running tests.
+
+        The name and URL here don't matter, this file doesn't need to exist.
+        """
+        return [
+            {
+                "name": f"test.{bundle_name}.bundle.js",
+                "url": "http://localhost:8000/static/bundles/test.bundle.js",
+            }
+        ]
+
+    def get_assets(self):
+        """
+        Effectively mocks out `webpack_static` template tag.
+
+        Return an empty asset stats object so that webpack_loader.utils.get_static()
+        does not raise an error.
+        """
+        return {}
+
+
+# Use a mock webpack loader class which does not actually look up webpack-stats.json,
+# as it will not be present during unit tests
+WEBPACK_LOADER = {
+    "DEFAULT": {
+        "LOADER_CLASS": "hedera.test_settings.TestingWebpackLoader",
+    }
+}

--- a/hedera/tests/test_api.py
+++ b/hedera/tests/test_api.py
@@ -1,5 +1,5 @@
 import json
-from random import randrange
+from uuid import uuid4
 
 from django.contrib.auth.models import User
 
@@ -18,7 +18,8 @@ from vocab_list.models import (
 class PersonalVocabularyQuickAddAPITest(APITestCase):
 
     def setUp(self):
-        self.created_user = User.objects.create_user(username=f"test_user{randrange(100)}", email=f"test_user{randrange(100)}@test.com", password="password")
+        test_username = f"test_user_{uuid4()}"
+        self.created_user = User.objects.create_user(username=test_username, email=f"{test_username}@test.com", password="password")
         self.client.force_login(user=self.created_user)
         self.personal_vocab_list = PersonalVocabularyList.objects.create(user=self.created_user, lang="lat")
         data = {
@@ -30,7 +31,8 @@ class PersonalVocabularyQuickAddAPITest(APITestCase):
         self.personal_vocab_list_entry = PersonalVocabularyListEntry.objects.create(**data)
 
     def test_fail_get_personal_vocabulary_quick_add_api(self):
-        self.created_user = User.objects.create_user(username=f"test_user{randrange(100)}", email=f"test_user{randrange(100)}@test.com", password="password")
+        test_username = f"test_user_{uuid4()}"
+        self.created_user = User.objects.create_user(username=test_username, email=f"{test_username}@test.com", password="password")
         self.client.force_login(user=self.created_user)
         response = self.client.get("/api/v1/personal_vocab_list/quick_add/")
         self.assertEqual(len(response.json()["data"]), 0)
@@ -161,7 +163,8 @@ class BookmarksListAPITest(APITestCase):
 class LatticeNodesAPITest(APITestCase):
 
     def setUp(self):
-        self.created_user = User.objects.create_user(username=f"test_user{randrange(100)}", email=f"test_user{randrange(100)}@test.com", password="password")
+        test_username = f"test_user_{uuid4()}"
+        self.created_user = User.objects.create_user(username=test_username, email=f"{test_username}@test.com", password="password")
         self.lattice_node = LatticeNode.objects.create(label="sum, esse, fuī", canonical=True, gloss="to be, exist")
         LemmaNode.objects.create(context="morpheus", lemma="sum", node_id=self.lattice_node.pk)
         self.client.force_login(user=self.created_user)
@@ -206,7 +209,8 @@ class LatticeNodesAPITest(APITestCase):
 
 class MeAPITest(APITestCase):
     def setUp(self):
-        self.created_user = User.objects.create_user(username=f"test_user{randrange(100)}", email=f"test_user{randrange(100)}@test.com", password="password")
+        test_username = f"test_user_{uuid4()}"
+        self.created_user = User.objects.create_user(username=test_username, email=f"{test_username}@test.com", password="password")
         self.client.force_login(user=self.created_user)
 
     def test_successful_post_me_profile_with_lang_field(self):


### PR DESCRIPTION
Provides instructions for running unit tests locally, and adds them to CI in a separate job (it will run in parallel with the build and code quality test job).

To get tests to work, we had to ensure that local and containerized test runs have access to postgres and redis, and that the tags in our templates provided by django-webpack-loader will not result in errors at test time if webpack hasn't actually been run to build static assets. This means that the webpages rendered by Django in unit tests do not have the real JS resources in them, so this approach isn't appropriate for end-to-end testing / UI interactions, but is quicker and more focused than also having to build and serve the webpack assets for each test run.

Steps to run tests are outlined in the README.md, but to summarize:

```
docker compose up -d postgres redis
# make sure postgres and redis are available, then run:
docker compose run --rm --no-deps -e DJANGO_SETTINGS_MODULE=hedera.test_settings django python manage.py test
# feel free to bring down postgres and redis after, e.g. `docker compose stop postgres redis`
```