### PR TITLE
Fix multiple obects returned error on lemmatized_text view

### DIFF
--- a/lemmatized_text/views.py
+++ b/lemmatized_text/views.py
@@ -79,7 +79,7 @@ def text(request, pk):
         Q(public=True) |
         Q(created_by=request.user) |
         Q(classes__teachers=request.user)
-    )
+    ).distinct()
     text = get_object_or_404(qs, pk=pk)
     return render(request, "lemmatized_text/text.html", {"text": text})
 


### PR DESCRIPTION
This PR resolves [ATGU-3377](https://jira.huit.harvard.edu/browse/ATGU-3377) by:

- Making sure sub queryset contains only unique lemmatized text objects

## Notes

The filter queryset was sometimes returning the same text many times, so when `get_object_or_404` was called on that queryset with pk as the identifier, it was producing a "too many objects returned" error, as it expects only  a single text to be returned.