### PR TITLE
Add props to make quick add vocab consistant with Personal vocab sele…

### DIFF
--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
      <div class="d-flex justify-content-between mb-2">
-       <QuickAddVocabForm class="mr-2 text-left" />
+       <QuickAddVocabForm class="mr-2 text-left" :current-lang-tab="lang"/>
        <DownloadVocab :glosses="glosses" :with-familiarity="true" />
      </div>
     <div v-if="personalVocabEntries">

--- a/static/src/js/app/components/quick-add-button/QuickAddButton.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddButton.vue
@@ -4,8 +4,9 @@
       ref="Modal"
       title="Add Word to Personal Vocabulary List"
       description="Modal to quick add vocab"
-      ><QuickAddVocabForm ref="QuickAddVocabForm"
-    /></Modal>
+      >
+        <QuickAddVocabForm ref="QuickAddVocabForm" :current-lang-tab="currentLangTab"/>
+      </Modal>
     <button type="button" class="btn btn-primary" @click="openModal">
       Quick Add Vocab
     </button>
@@ -17,6 +18,7 @@
 
   export default {
     components: { Modal, QuickAddVocabForm },
+    props: ['currentLangTab'],
     methods: {
       openModal() {
         this.$refs.Modal.toggleModal();

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -121,6 +121,7 @@
 
   export default {
     components: { FamiliarityRating },
+    props: ['currentLangTab'],
     // on creation of the dom element fetch the list of langauages/ids the user has in their personal vocab list
     async created() {
       await this.$store.dispatch(FETCH_PERSONAL_VOCAB_LANG_LIST);
@@ -139,6 +140,13 @@
       } else {
         const [langItem] = this.personalVocabLangList;
         this.vocabularyListItem = langItem;
+      }
+      // change language option to what the currently selected tab on PersonalVocab.vue
+      if (this.currentLangTab) {
+        const foundLangListItem = this.personalVocabLangList.find(
+          (ele) => ele.lang === this.currentLangTab,
+        );
+        this.vocabularyListItem = foundLangListItem;
       }
     // await this.$store.dispatch(FETCH_SUPPORTED_LANG_LIST);
     },


### PR DESCRIPTION
- Fix quick add default language to currently selected Personal Vocab tab
Note: The quick add button in the Navigation wont have access to the language from the Personal Vocab tab because the Nav is rendered using Django while the Personal Vocab is using Vue