### PR TITLE
Fix quick add suggested gloss so other languages can lookup headwords

### DIFF
--- a/docker-compose-common.yml
+++ b/docker-compose-common.yml
@@ -25,6 +25,7 @@ services:
             - ./lti/:/app/lti
             - ./pdfservice/:/app/pdfservice
             - ./static/src/:/app/static/src
+            - ./webpack-stats/:/app/webpack-stats
             - ./vocab_list/:/app/vocab_list
             - ./manage.py/:/app/manage.py
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,9 @@ services:
             target: prod
         container_name: hedera-npm
         working_dir: /app
+        volumes:
+            - ./static/src/:/app/static/src
+            - ./webpack-stats/:/app/webpack-stats
         networks:
             - localdev
         ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "hedera",
       "version": "1.0.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -65,7 +65,7 @@ export default {
   createPersonalVocabEntry: (headword, gloss, vocabularyListId, familiarity, node, lang, cb) => axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, {
     headword, gloss, familiarity, vocabulary_list_id: vocabularyListId, node, lang,
   }).then((r) => cb(r.data)),
-  fetchLatticeNodes: (headword, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}`).then((r) => cb(r.data)),
+  fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),
   updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
   deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
   fetchBookmarks: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -229,13 +229,9 @@
         this.$store.dispatch(RESET_LATTICE_NODES_BY_HEADWORD);
       },
       async getHeadword() {
-        /**
-         * TODO add more languages for searches
-         * conditional to only get headword for Latin for now
-         * */
-        if (this.vocabularyListItem && this.vocabularyListItem.lang !== 'lat') return;
         await this.$store.dispatch(FETCH_LATTICE_NODES_BY_HEADWORD, {
           headword: this.headword,
+          lang: this.vocabularyListItem.lang,
         });
         // sets first latticenode as the default in select options
         if (this.latticeNode) {
@@ -276,12 +272,6 @@
       },
       // filters lattice node to exclude parent data for simplier UI in LatticeNode component
       latticeNode() {
-        /**
-         * TODO add more languages
-         * conditional to only get headword for Latin for now
-         * */
-        const { vocabularyListItem } = this;
-        if (vocabularyListItem && vocabularyListItem.lang !== 'lat') return null;
         const nodes = this.$store.state.latticeNodes || [];
         if (!nodes.length) return null;
         const formatedNodes = nodes.map((node) => {

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -111,9 +111,9 @@ export default {
       .createPersonalVocabEntry(headword, gloss, vocabularyListId, familiarity, node, lang, cb)
       .catch(logoutOnError(commit));
   },
-  [FETCH_LATTICE_NODES_BY_HEADWORD]: ({ commit }, { headword }) => {
+  [FETCH_LATTICE_NODES_BY_HEADWORD]: ({ commit }, { headword, lang }) => {
     const cb = (data) => commit(FETCH_LATTICE_NODES_BY_HEADWORD, data.data);
-    return api.fetchLatticeNodes(headword, cb).catch(logoutOnError(commit));
+    return api.fetchLatticeNodes(headword, lang, cb).catch(logoutOnError(commit));
   },
   // TODO: might be a better way to reset this state but this works for now
   [RESET_LATTICE_NODES_BY_HEADWORD]: ({ commit }) => commit(RESET_LATTICE_NODES_BY_HEADWORD),


### PR DESCRIPTION
- removed blocking code from quick add component so other languages can lookup headwords
- Added extra parameter when looking up headwords
Note: as of right now there is no way to distinguish/match languages between glosses that is returned. Chinese is the only language that can be matched via context on the lattice node. However Russian, and Latin context are referenced with `Clancy` and `Morpheus` respectively. We would need a way to validate that the actual gloss thats returned is for the correct language.(I am not sure about Greek since there doesn't seem to be a script to load that lattice in)