### PR TITLE
Hedera Dojo 2022-08-18

### DIFF
--- a/lemmatization/admin.py
+++ b/lemmatization/admin.py
@@ -1,0 +1,23 @@
+from django.contrib import admin
+
+from . import models
+
+
+class LemmaAdmin(admin.ModelAdmin):
+    list_display = ("lang", "lemma", "alt_lemma", "label", "rank")
+    search_fields = ["lemma__iexact"]
+
+
+class FormToLemmaAdmin(admin.ModelAdmin):
+    list_display = ("lang", "form", "lemma")
+    search_fields = ["form__iexact"]
+
+
+class GlossAdmin(admin.ModelAdmin):
+    list_display = ("lemma", "gloss")
+    search_fields = ["lemma__iexact"]
+
+
+admin.site.register(models.Lemma, LemmaAdmin)
+admin.site.register(models.FormToLemma, FormToLemmaAdmin)
+admin.site.register(models.Gloss, GlossAdmin)

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -36,8 +36,8 @@ class Lemmatizer(object):
     def _tokenize(self, text):
         return self._tokenizer.tokenize(text)
 
-    def _lemmatize_token(self, token):
-        lemmas = self._service.lemmatize(token)
+    def _lemmatize_token(self, word, word_normalized):
+        lemmas = self._service.lemmatize(word, word_normalized)
         return list(lemmas)
 
     def _report_progress(self, index, total_count):
@@ -60,12 +60,13 @@ class Lemmatizer(object):
         total_count = len(tokens)
         for index, token in enumerate(tokens):
             word, word_normalized, following = token
+
             lemma_id = None
             gloss_ids = []
             glossed = GLOSSED_NA
             resolved = RESOLVED_NA
             if word_normalized:
-                lemma_names = self._lemmatize_token(word_normalized)
+                lemma_names = self._lemmatize_token(word, word_normalized)
                 lemma_entries = Lemma.objects.filter(lang=self.lang, lemma__in=lemma_names).order_by("rank")
 
                 # automatically select the highest frequency lemma

--- a/lemmatization/models.py
+++ b/lemmatization/models.py
@@ -42,6 +42,9 @@ class Lemma(models.Model):
             glosses=[gloss.to_dict() for gloss in self.glosses.all()],
         )
 
+    def __str__(self):
+        return self.lemma
+
     class Meta:
         constraints = [
             models.UniqueConstraint(fields=["lemma", "lang"], name="unique_lemma_lang")


### PR DESCRIPTION
This PR is the result of a coding session with @bilbe @Tanvez and @arthurian. The primary goal of the session was to update the lemmatizaton process for latin to handle words with macrons such that if `hīc` appears in a text, it can be lemmatized as `hic2` immediately. The default case is that `hic` is lemmatized and returns two options: `hic1` and `hic2`. While we can't say for certain which one is meant for `hic`, we know that `hīc` always means `hic2`.

Changes:
- Updated `latin.py` lemmatizer so that if a macron is detected in a word, perform a form2lemma lookup immediately and use the result if it's found, otherwise fallback to looking up the normalized word. We tested this and it appears to be working as expected, once we added an entry in the form2lemma table for `hīc -> hic2`.
- Updated the admin interface to show the `Lemma`, `Gloss`, and `Form2Lemma` models. If nothing else, this provides a simple way to check the data and/or update it on the fly.

Outstanding issues:
- We need to fix the frontend so that it queries `http://localhost:8000/api/v1/lemmatization/forms/lat/{word}` appropriately.  In other words, if `hic` is the form, then it should query that, but if `hīc` (with the macron) is the word that was lemmatized, then that should be used instead. It looks like it's currently using `hic` for both cases (the normalized version with macrons stripped).
- The data import appears to be missing entries for `hic` (no macron) in the form2lemma table. The form `hic` should have two possible lemmas: `hic1` and `hic2`. We'll need to add `hīc` as well since it's not already there and have it map to `hic2`.

Follow-up notes:
- Since the lemmatizer is now making a decision about whether to use the `word` or `word_normalized` when doing the form2lemma lookup, it may make sense to change the tokenizer to return 2-tuples instead of 3-tuples (e.g. `(word, following)` instead of `(word, word_normalized, following)`). If that happens, then we might want to have the lemmatizer to return both the lemmas AND the form that resulted in those lemmas (since it could be the word with macrons or the stripped/normalized version of the word).
