### PR TITLE
Refactor lemmatizer enclitics

### DIFF
--- a/hedera/supported_languages.py
+++ b/hedera/supported_languages.py
@@ -26,7 +26,6 @@ from lemmatization.services.russian import (
 
 SupportedLanguage = namedtuple("SupportedLanguage", ["code", "verbose_name", "service", "tokenizer", "preprocessor"])
 
-# TODO add preprocessor to each language - ex latin enclitics lookup
 SUPPORTED_LANGUAGES = {
     "grc": SupportedLanguage("grc", "Ancient Greek", GreekService(lang="grc"), GreekTokenizer(lang="grc"), GreekPreprocessor(lang="grc")),
     "lat": SupportedLanguage("lat", "Latin", LatinService(lang="lat"), EncliticTokenizer(lang="lat"), LatinPreprocessor(lang="lat")),

--- a/hedera/supported_languages.py
+++ b/hedera/supported_languages.py
@@ -1,19 +1,35 @@
 from collections import namedtuple
 
-from lemmatization.services.chinese import ChineseService, LACChineseTokenizer
-from lemmatization.services.greek import GreekService, GreekTokenizer
-from lemmatization.services.latin import EncliticTokenizer, LatinService
-from lemmatization.services.russian import ClancyService, RUSTokenizer
+from lemmatization.services.chinese import (
+    ChinesePreprocessor,
+    ChineseService,
+    LACChineseTokenizer
+)
+from lemmatization.services.greek import (
+    GreekPreprocessor,
+    GreekService,
+    GreekTokenizer
+)
+from lemmatization.services.latin import (
+    EncliticTokenizer,
+    LatinPreprocessor,
+    LatinService
+)
+from lemmatization.services.russian import (
+    ClancyService,
+    RUSPreprocessor,
+    RUSTokenizer
+)
 
 
 # using ISO 639.2 CODES
 
-SupportedLanguage = namedtuple("SupportedLanguage", ["code", "verbose_name", "service", "tokenizer"])
+SupportedLanguage = namedtuple("SupportedLanguage", ["code", "verbose_name", "service", "tokenizer", "preprocessor"])
 
 # TODO add preprocessor to each language - ex latin enclitics lookup
 SUPPORTED_LANGUAGES = {
-    "grc": SupportedLanguage("grc", "Ancient Greek", GreekService(lang="grc"), GreekTokenizer(lang="grc")),
-    "lat": SupportedLanguage("lat", "Latin", LatinService(lang="lat"), EncliticTokenizer(lang="lat")),
-    "rus": SupportedLanguage("rus", "Russian", ClancyService(lang="rus"), RUSTokenizer(lang="rus")),
-    "zho": SupportedLanguage("zho", "Chinese", ChineseService(lang="zho"), LACChineseTokenizer(lang="zho"))
+    "grc": SupportedLanguage("grc", "Ancient Greek", GreekService(lang="grc"), GreekTokenizer(lang="grc"), GreekPreprocessor(lang="grc")),
+    "lat": SupportedLanguage("lat", "Latin", LatinService(lang="lat"), EncliticTokenizer(lang="lat"), LatinPreprocessor(lang="lat")),
+    "rus": SupportedLanguage("rus", "Russian", ClancyService(lang="rus"), RUSTokenizer(lang="rus"), RUSPreprocessor(lang="rus")),
+    "zho": SupportedLanguage("zho", "Chinese", ChineseService(lang="zho"), LACChineseTokenizer(lang="zho"), ChinesePreprocessor(lang="zho"))
 }

--- a/hedera/supported_languages.py
+++ b/hedera/supported_languages.py
@@ -10,7 +10,7 @@ from lemmatization.services.russian import ClancyService, RUSTokenizer
 
 SupportedLanguage = namedtuple("SupportedLanguage", ["code", "verbose_name", "service", "tokenizer"])
 
-
+# TODO add preprocessor to each language - ex latin enclitics lookup
 SUPPORTED_LANGUAGES = {
     "grc": SupportedLanguage("grc", "Ancient Greek", GreekService(lang="grc"), GreekTokenizer(lang="grc")),
     "lat": SupportedLanguage("lat", "Latin", LatinService(lang="lat"), EncliticTokenizer(lang="lat")),

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -65,7 +65,8 @@ class Lemmatizer(object):
             - que, " "
         check if its enclitic and split
         """
-        tokens = find_latin_enclitics(tokens)
+        # transformation - generic processing step -> lemmatizer
+        # tokens = preprocessing_tokens(tokens)
         total_count = len(tokens)
         for index, token in enumerate(tokens):
             word, word_normalized, following = token

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -28,10 +28,13 @@ class Lemmatizer(object):
         self.force_refresh = force_refresh
         self._service = SUPPORTED_LANGUAGES[lang].service
         self._tokenizer = SUPPORTED_LANGUAGES[lang].tokenizer
+        self._preprocessor = SUPPORTED_LANGUAGES[lang].preprocessor
         if self._service is None:
             raise ValueError(f"Lemmatization not supported for language '{lang}''")
         if self._tokenizer is None:
             raise ValueError(f"Tokenization not supported for language '{lang}''")
+        if self._preprocessor is None:
+            raise ValueError(f"Preprocessor not supported for language '{lang}''")
 
     def _tokenize(self, text):
         return self._tokenizer.tokenize(text)
@@ -45,34 +48,22 @@ class Lemmatizer(object):
             self.cb((index + 1) / total_count)
 
     def lemmatize(self, text):
-        import debugpy
+        # import debugpy
 
-        try:
-            debugpy.listen(("0.0.0.0", 5678))
-            print("Waiting for debugger attach")
-            debugpy.wait_for_client()
-            debugpy.breakpoint()
-            print('break on this line')
-        except:
-            pass
+        # try:
+        #     debugpy.listen(("0.0.0.0", 5678))
+        #     print("Waiting for debugger attach")
+        #     debugpy.wait_for_client()
+        #     debugpy.breakpoint()
+        #     print('break on this line')
+        # except:
+        #     pass
         result = []
-        tokens = list(self._tokenize(text)) 
-        #tokens = ['virum', '', 'que']
-        """
-            text = virumque, " "
-            Broken into:
-            - virum, ""
-            - que, " "
-        check if its enclitic and split
-        """
-        # transformation - generic processing step -> lemmatizer
-        # tokens = preprocessing_tokens(tokens)
+        tokens = list(self._tokenize(text))
+        tokens = self._preprocessor.preprocessor(tokens)
         total_count = len(tokens)
         for index, token in enumerate(tokens):
             word, word_normalized, following = token
-            """
-            [virum, "", que] = find_latin_enclitics("virumque")
-            """
             lemma_id = None
             gloss_ids = []
             glossed = GLOSSED_NA

--- a/lemmatization/lemmatizer.py
+++ b/lemmatization/lemmatizer.py
@@ -45,22 +45,33 @@ class Lemmatizer(object):
             self.cb((index + 1) / total_count)
 
     def lemmatize(self, text):
-        # import debugpy
+        import debugpy
 
-        # try:
-        #     debugpy.listen(("0.0.0.0", 5678))
-        #     print("Waiting for debugger attach")
-        #     debugpy.wait_for_client()
-        #     debugpy.breakpoint()
-        #     print('break on this line')
-        # except:
-        #     pass
+        try:
+            debugpy.listen(("0.0.0.0", 5678))
+            print("Waiting for debugger attach")
+            debugpy.wait_for_client()
+            debugpy.breakpoint()
+            print('break on this line')
+        except:
+            pass
         result = []
-        tokens = list(self._tokenize(text))
+        tokens = list(self._tokenize(text)) 
+        #tokens = ['virum', '', 'que']
+        """
+            text = virumque, " "
+            Broken into:
+            - virum, ""
+            - que, " "
+        check if its enclitic and split
+        """
+        tokens = find_latin_enclitics(tokens)
         total_count = len(tokens)
         for index, token in enumerate(tokens):
             word, word_normalized, following = token
-
+            """
+            [virum, "", que] = find_latin_enclitics("virumque")
+            """
             lemma_id = None
             gloss_ids = []
             glossed = GLOSSED_NA

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -88,3 +88,23 @@ class Tokenizer(object):
         This method must be overridden.
         """
         raise NotImplementedError("Must provide implementation on a per tokenizer basis.")
+
+
+class Preprocessor(object):
+    """
+    Preprocessor for running custom transformation of tokens list.
+
+    Subclasses should override the preprocessor() method to provide
+    language-specific preprocessor.
+    """
+
+    def __init__(self, lang):
+        self.lang = lang
+
+    def preprocessor(self, tokens):
+        """
+        Returns an iterable list of tokens if a custom preprocessor was provided
+
+        This method must be overridden.
+        """
+        raise NotImplementedError("Must provide implementation on a per preprocessor basis.")

--- a/lemmatization/services/chinese.py
+++ b/lemmatization/services/chinese.py
@@ -8,7 +8,7 @@ from typing import (  # can use `list` and `tuple` in python 3.9
 
 from LAC import LAC
 
-from .base import BaseService, Tokenizer
+from .base import BaseService, Preprocessor, Tokenizer
 
 
 TripleIterable = Iterable[Tuple[str, str, str]]
@@ -227,3 +227,12 @@ class LACChineseTokenizer(ChineseTokenizer):
                     subtoken += char
             if subtoken:
                 yield subtoken
+
+
+class ChinesePreprocessor(Preprocessor):
+    """
+    Returns an iterable list of tokens if a custom preprocessor was provided
+    This placeholder method can be overridden.
+    """
+    def preprocessor(self, tokens: List[tuple]) -> List[tuple]:
+        return tokens

--- a/lemmatization/services/greek.py
+++ b/lemmatization/services/greek.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 
-from .base import HttpService, Tokenizer, triples
+from .base import HttpService, Preprocessor, Tokenizer, triples
 
 
 class MorpheusService(HttpService):
@@ -44,3 +44,12 @@ class GreekTokenizer(Tokenizer):
         text = unicodedata.normalize("NFC", text)
         tokens = re.split(r"(\W+)", text)
         return triples(tokens)
+
+
+class GreekPreprocessor(Preprocessor):
+    """
+    Returns an iterable list of tokens if a custom preprocessor was provided
+    This placeholder method can be overridden.
+    """
+    def preprocessor(self, tokens):
+        return tokens

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -150,6 +150,8 @@ class LatinPreprocessor(Preprocessor):
                 new_tokens.append(token)
             else:
                 found_form_normalized = lookup_form(word_normalized, "lat")
+                if found_form_normalized:
+                    new_tokens.append(token)
                 if not found_form_normalized:
                     for enclitic in LATIN_ENCLITICS:
                         if word.endswith(enclitic) and found_first_enclitic is False:

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -55,7 +55,7 @@ def re_tokenize_clitics(tokens):
         else:
             yield token
 
-def find_latin_enclitics(tokens: List(str)) -> List[str]:
+def find_latin_enclitics(tokens: List[str]) -> List[str]:
     """
     This function finds the enclitics attached to the word and returns a list of two strings
     ex: ["virum", "que"]
@@ -115,23 +115,24 @@ class LatinService(BaseService):
 
         Results are returned in order of highest frequency (rate) first, or simply
         alphabetical by lemma if there is no frequency data.
+        
         """
         # TODO: Move the normalization step HERE instead of the tokenizer.
         # The tokenizers should return doubles: (word, following) instead of triples.
         lemmas = []
-        # if has_macron(word):
-        #     lemmas = lookup_form(word, "lat")
-        # if not lemmas:
-        #     lemmas = lookup_form(word_normalized, "lat")
+        if has_macron(word):
+            lemmas = lookup_form(word, "lat")
+        if not lemmas:
+            lemmas = lookup_form(word_normalized, "lat")
         # # TODO: if not found strip out enclitic matching -que, -qve, -ue, -ve, -ne, -met
         # # then do the lookup without that
         # # should do what tokenize does - ex: ['virum', 'que']
         # print("word.endswith(LATIN_ENCLITICS)", word.endswith(LATIN_ENCLITICS))
         # if word.endswith(LATIN_ENCLITICS) and not lemmas:
-        word_enclitics_list = find_latin_enclitics(word)
-        word1 = lookup_form(word_enclitics_list[0], "lat")
-        enclitics = lookup_form(word_enclitics_list[1], "lat")
-        lemmas = word1 + enclitics
+        # word_enclitics_list = find_latin_enclitics(word)
+        # word1 = lookup_form(word_enclitics_list[0], "lat")
+        # enclitics = lookup_form(word_enclitics_list[1], "lat")
+        # lemmas = word1 + enclitics
         return lemmas
 
 

--- a/lemmatization/services/russian.py
+++ b/lemmatization/services/russian.py
@@ -1,7 +1,7 @@
 import re
 import unicodedata
 
-from .base import HttpService, Tokenizer, triples
+from .base import HttpService, Preprocessor, Tokenizer, triples
 
 
 def maketrans_remove(accents=("COMBINING ACUTE ACCENT", "COMBINING GRAVE ACCENT")):
@@ -94,3 +94,12 @@ class RUSTokenizer(Tokenizer):
             else:
                 processed.append(token)
         return processed
+
+
+class RUSPreprocessor(Preprocessor):
+    """
+    Returns an iterable list of tokens if a custom preprocessor was provided
+    This placeholder method can be overridden.
+    """
+    def preprocessor(self, tokens):
+        return tokens

--- a/lemmatization/tests/test_data.py
+++ b/lemmatization/tests/test_data.py
@@ -1,0 +1,67 @@
+test_data_list = [
+    {
+        "form": "ratiōne",
+        "lang": "lat",
+        "lemma_data": {
+                "lemma": "ratio",
+                "alt_lemma": "ratio",
+                "label": "ratiō, ratiōnis, f.",
+                "rank": 117,
+                "count": 4694,
+                "rate": 10.566,
+                "lang": "lat"
+        }
+    },
+    {
+        "form": "ratione",
+        "lang": "lat",
+        "lemma_data": {
+                "lemma": "ratio",
+                "alt_lemma": "ratio",
+                "label": "ratiō, ratiōnis, f.",
+                "rank": 117,
+                "count": 4694,
+                "rate": 10.566,
+                "lang": "lat"
+        }
+    },
+    {
+        "form": "sum",
+        "lang": "lat",
+        "lemma_data": {
+            "lemma": "sum",
+            "alt_lemma": "sum1",
+            "label": "sum, esse, fuī",
+            "rank": 1,
+            "count": 145573,
+            "rate": 327.682,
+            "lang": "lat"
+        },
+    },
+    {
+        "form": "que",
+        "lang": "lat",
+        "lemma_data": {
+            "lemma": "que",
+            "alt_lemma": "que",
+            "label": "que",
+            "rank": 1692,
+            "count": 362,
+            "rate": 0.815,
+            "lang": "lat",
+        }
+    },
+    {
+        "form": "virum",
+        "lang": "lat",
+        "lemma_data": {
+            "lemma": "vir",
+            "alt_lemma": "uir",
+            "label": "vir, virī m.",
+            "rank": 87,
+            "count": 6258,
+            "rate": 14.087,
+            "lang": "lat",
+        }
+    }
+]

--- a/lemmatization/tests/test_preprocessors.py
+++ b/lemmatization/tests/test_preprocessors.py
@@ -1,0 +1,52 @@
+from django.test import TransactionTestCase
+
+from ..models import FormToLemma, Lemma
+from ..services.latin import LatinPreprocessor
+from .test_data import test_data_list
+
+
+class LatinPreprocessorTests(TransactionTestCase):
+    def setUp(self):
+        for form_data in test_data_list:
+            lemma_data = form_data["lemma_data"]
+            lemma_qs = Lemma.objects.filter(lang=lemma_data["lang"], lemma=lemma_data["lemma"])
+            if not lemma_qs.exists():
+                lemma = Lemma.objects.create(**lemma_data)
+                FormToLemma.objects.create(lang=form_data["lang"], lemma=lemma, form=form_data["form"])
+
+    def test_successful_word_with_enclitics(self):
+        """
+        Test word splitting on enclitic based on form exist in `FormtoLemma` table
+        """
+        input_tokens = [("virumque", "virumque", " ")]
+        expected_result = [("virum", "que", ""), ("que", "que", " ")]
+        self.assertEqual(
+            LatinPreprocessor(lang="lat").preprocessor(input_tokens), expected_result
+        )
+
+    def test_word_with_macron_without_enclitics(self):
+        """
+        Test word with macrons but no enclitics
+        """
+        input_tokens = [("ratiōne", "ratione", " ")]
+        self.assertEqual(
+            LatinPreprocessor(lang="lat").preprocessor(input_tokens), input_tokens
+        )
+
+    def test_word_without_enclitics(self):
+        """
+        Test word with no enclitics
+        """
+        input_tokens = [("sum", "sum", " ")]
+        self.assertEqual(
+            LatinPreprocessor(lang="lat").preprocessor(input_tokens), input_tokens
+        )
+
+    def test_name_without_enclitics(self):
+        """
+        Test name without any enclitics particles
+        """
+        input_tokens = [("Medea", "Medea", " ")]
+        self.assertEqual(
+            LatinPreprocessor(lang="lat").preprocessor(input_tokens), input_tokens
+        )

--- a/static/src/js/app/modules/FormDisambiguation.vue
+++ b/static/src/js/app/modules/FormDisambiguation.vue
@@ -37,7 +37,6 @@
         gloss_ids: [...this.$store.state.selectedToken.gloss_ids],
       };
     },
-
     methods: {
       onLemmaChange(lemma) {
         this.updateLemma(lemma);
@@ -100,7 +99,7 @@
       selectedForm() {
         return (
           this.selectedToken
-          && this.$store.state.forms[this.selectedToken.word_normalized]
+          && this.$store.state.forms[this.selectedToken.word]
         );
       },
       activeGlosses() {

--- a/static/src/js/app/modules/LemmatizedText.vue
+++ b/static/src/js/app/modules/LemmatizedText.vue
@@ -77,12 +77,10 @@
         };
 
         const fetchLemmasByForm = () => {
-          if (this.selectedToken.word_normalized) {
-            this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
-              lang: this.$store.state.text.lang,
-              form: this.selectedToken.word_normalized,
-            });
-          }
+          this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
+            lang: this.$store.state.text.lang,
+            form: this.selectedToken.word,
+          })
         };
 
         const debouncedFetch = debounce(() => {

--- a/static/src/js/app/modules/LemmatizedText.vue
+++ b/static/src/js/app/modules/LemmatizedText.vue
@@ -80,7 +80,7 @@
           this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
             lang: this.$store.state.text.lang,
             form: this.selectedToken.word,
-          })
+          });
         };
 
         const debouncedFetch = debounce(() => {


### PR DESCRIPTION
This PR adds the following:
- A preprocessor class to `base.py` and `lemmatizer.py` to further parse out enclitics from an already tokenized words in a latin text. Note: Placeholder methods are created for other languages(chinese, russian, and greek)
- Test for the latin preprocessor
- Changes were made to the front-end to account for words lookup_form that includes macrons