### PR TITLE
Add pdf-service to docker compose and fix handout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,17 @@ services:
             - localdev
         ports:
             - "6379:6379"
-
+    pdfservice:
+        image: eldarioninc/pdf-service
+        container_name: hedera-pdfservice
+        restart: unless-stopped
+        environment:
+          X_API_KEY: "pdfservice-api-key"
+        networks:
+          - localdev
+        ports:
+          - "9000:9000"
+        command: /bin/sh -c 'exec gunicorn --bind 0.0.0.0:9000 wsgi:app'
     npm:
         image: hedera-django
         build:
@@ -49,6 +59,9 @@ services:
             file: docker-compose-common.yml
             service: django
         container_name: hedera-django
+        environment:
+          PDF_SERVICE_ENDPOINT: "http://pdfservice:9000/pdf"
+          PDF_SERVICE_KEY: "pdfservice-api-key"
         ports:
             - "5678:5678"  # 5678 is default port for debugpy
             - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
         ports:
             - "6379:6379"
     pdfservice:
+        # This service is a small wrapper (flask app) around puppeteer (https://pptr.dev/)
+        # that takes HTML and converts to PDF.
         image: eldarioninc/pdf-service
         container_name: hedera-pdfservice
         restart: unless-stopped

--- a/hedera/templates/lemmatized_text/handout.html
+++ b/hedera/templates/lemmatized_text/handout.html
@@ -85,10 +85,10 @@
       </div>
       <div class="glossary">
         <h4>Glossary</h4>
-        {% for node in words %}
+        {% for word in glossary %}
           <div class="word">
-            <span class="label">{{ node.label }}</span>
-            <span class="gloss">{{ node.gloss }}</span>
+            <span class="label">{{ word.label }}</span>
+            <span class="gloss">{{ word.glosses | join:"; " }}</span>
           </div>
         {% endfor %}
       </div>

--- a/hedera/tests/test_api.py
+++ b/hedera/tests/test_api.py
@@ -7,7 +7,6 @@ from rest_framework.test import APITestCase
 
 from hedera.supported_languages import SUPPORTED_LANGUAGES
 from hedera.tests import utils
-from lattices.models import LatticeNode, LemmaNode
 from lemmatized_text.models import LemmatizedTextBookmark
 from vocab_list.models import (
     PersonalVocabularyList,
@@ -158,53 +157,6 @@ class BookmarksListAPITest(APITestCase):
 
         content = json.loads(response.content)
         self.assertEqual(new_text.pk, content["data"]["text"]["id"])
-
-
-class LatticeNodesAPITest(APITestCase):
-
-    def setUp(self):
-        test_username = f"test_user_{uuid4()}"
-        self.created_user = User.objects.create_user(username=test_username, email=f"{test_username}@test.com", password="password")
-        self.lattice_node = LatticeNode.objects.create(label="sum, esse, fuī", canonical=True, gloss="to be, exist")
-        LemmaNode.objects.create(context="morpheus", lemma="sum", node_id=self.lattice_node.pk)
-        self.client.force_login(user=self.created_user)
-
-    def test_get_related_lattice_nodes(self):
-        response = self.client.get("/api/v1/lattice_nodes/?headword=sum")
-        success_response = [
-            {
-                "pk": self.lattice_node.pk,
-                "label": "sum, esse, fuī",
-                "gloss": "to be, exist",
-                "canonical": True,
-                "forms": [],
-                "lemmas": [
-                    {
-                        "lemma": "sum",
-                        "context": "morpheus"
-                    }
-                ],
-                "vocabulary_entries": [],
-                "children": [],
-                "parents": []
-            }
-        ]
-        json_response = response.json()["data"]
-        self.assertEqual(json_response[0]["pk"], success_response[0]["pk"])
-        self.assertEqual(json_response[0]["label"], success_response[0]["label"])
-        self.assertEqual(json_response[0]["lemmas"], success_response[0]["lemmas"])
-
-    def test_fail_to_get_related_lattice_nodes(self):
-        response = self.client.get("/api/v1/lattice_nodes/?headword=ssss")
-        self.assertEqual(len(response.json()["data"]), 0)
-
-    def test_fail_headword_not_provided(self):
-        response = self.client.get("/api/v1/lattice_nodes/?headword=")
-        self.assertEqual(len(response.json()["data"]), 0)
-
-    def test_fail_headword_query_key_not_provided(self):
-        response = self.client.get("/api/v1/lattice_nodes/")
-        self.assertEqual(response.json()["error"], "Missing headword")
 
 
 class MeAPITest(APITestCase):

--- a/hedera/urls.py
+++ b/hedera/urls.py
@@ -50,7 +50,6 @@ urlpatterns = [
     path("api/v1/personal_vocab_list/", api.PersonalVocabularyListAPI.as_view()),
     path("api/v1/personal_vocab_list/<int:pk>/", api.PersonalVocabularyListAPI.as_view()),
     path("api/v1/personal_vocab_list/quick_add/", api.PersonalVocabularyQuickAddAPI.as_view()),
-    path("api/v1/lattice_nodes/", api.LatticeNodesAPI.as_view()),
     path("api/v1/supported_languages/", api.SupportedLanguagesAPI.as_view()),
 
     path("lti/", include("lti_provider.urls")),

--- a/lemmatization/models.py
+++ b/lemmatization/models.py
@@ -105,6 +105,9 @@ class Gloss(models.Model):
             gloss=self.gloss,
         )
 
+    class Meta:
+        ordering = ["lemma", "gloss"]
+
 
 def lookup_form(form, lang) -> List[str]:
     """ Returns a list of lemmas (strings) in frequency order. """

--- a/lemmatized_text/models.py
+++ b/lemmatized_text/models.py
@@ -255,11 +255,24 @@ class LemmatizedText(models.Model):
             )
             for token in self.data
         ])
-    """
-    check if user has the filtered_group ids in ther enrolled classes or taught classes
-    Note: only checks if user is related to at least one class with the same text/group id
-    """
+
+    def transform_data_to_glossary(self):
+        """Returns a list of words used in the text with their full glosses."""
+        lemma_ids = [token["lemma_id"] for token in self.data if token.get("lemma_id")]
+        lemma_queryset = Lemma.objects.filter(pk__in=lemma_ids).order_by("label")
+        glossary = []
+        for lemma_object in lemma_queryset:
+            glossary.append({
+                "label": lemma_object.label,
+                "glosses": [gloss_object.gloss for gloss_object in lemma_object.glosses.all()],
+            })
+        return glossary
+
     def is_valid_user(self, user):
+        """
+        check if user has the filtered_group ids in their enrolled classes or taught classes
+        Note: only checks if user is related to at least one class with the same text/group id
+        """
         groups = self.classes.all()
         filtered_groups = groups.filter(texts__in=[self.pk])
         enrolled_classes = user.enrolled_classes.all()

--- a/lemmatized_text/views.py
+++ b/lemmatized_text/views.py
@@ -8,11 +8,10 @@ from django.views.decorators.http import require_POST
 from django.views.generic import DetailView
 
 from hedera.supported_languages import SUPPORTED_LANGUAGES
-from lattices.models import LatticeNode
 from pdfservice.mixins import PDFResponseMixin
 
-from . import models
 from .forms import LemmatizedTextEditForm
+from .models import LemmatizedText
 
 
 def lemmatized_texts(request):
@@ -25,7 +24,7 @@ def create(request):
         title = request.POST.get("title")
         lang = request.POST.get("lang")
         text = request.POST.get("text")
-        lt = models.LemmatizedText.objects.create(
+        lt = LemmatizedText.objects.create(
             title=title,
             lang=lang,
             data={},
@@ -37,7 +36,7 @@ def create(request):
 
     # the GET is for initial page or getting the cloned from object
     if request.GET.get("cloned_from"):
-        lemmatized_text = get_object_or_404(models.LemmatizedText, pk=request.GET.get("cloned_from"))
+        lemmatized_text = get_object_or_404(LemmatizedText, pk=request.GET.get("cloned_from"))
         lemmatized_text.clone(cloned_by=request.user)
         return redirect("lemmatized_texts_list")
 
@@ -45,7 +44,7 @@ def create(request):
     languages = [[lang.code, lang.verbose_name] for lang in SUPPORTED_LANGUAGES.values()]
     # create the  selected language here, which is the lanaguage of the last submitted text
     try:
-        select_lang = models.LemmatizedText.objects.filter(created_by=request.user).order_by("-pk")[0].lang
+        select_lang = LemmatizedText.objects.filter(created_by=request.user).order_by("-pk")[0].lang
     except Exception as e:
         logging.exception(e)
 
@@ -54,20 +53,20 @@ def create(request):
 
 @require_POST
 def retry_lemmatization(request, pk):
-    text = get_object_or_404(models.LemmatizedText, pk=pk, created_by=request.user)
+    text = get_object_or_404(LemmatizedText, pk=pk, created_by=request.user)
     text.retry_lemmatization()
     return redirect("lemmatized_texts_list")
 
 
 @require_POST
 def cancel_lemmatization(request, pk):
-    text = get_object_or_404(models.LemmatizedText, pk=pk, created_by=request.user)
+    text = get_object_or_404(LemmatizedText, pk=pk, created_by=request.user)
     text.cancel_lemmatization()
     return redirect("lemmatized_texts_list")
 
 
 def delete(request, pk):
-    text = get_object_or_404(models.LemmatizedText, pk=pk, created_by=request.user)
+    text = get_object_or_404(LemmatizedText, pk=pk, created_by=request.user)
     if request.method == "POST":
         text.delete()
         return redirect("lemmatized_texts_list")
@@ -75,7 +74,7 @@ def delete(request, pk):
 
 
 def text(request, pk):
-    qs = models.LemmatizedText.objects.filter(
+    qs = LemmatizedText.objects.filter(
         Q(public=True) |
         Q(created_by=request.user) |
         Q(classes__teachers=request.user)
@@ -85,7 +84,7 @@ def text(request, pk):
 
 
 def edit(request, pk):
-    lemmatized_text = get_object_or_404(models.LemmatizedText, pk=pk, created_by=request.user)
+    lemmatized_text = get_object_or_404(LemmatizedText, pk=pk, created_by=request.user)
 
     if request.method == "POST":
         form = LemmatizedTextEditForm(request.POST)
@@ -103,7 +102,7 @@ def edit(request, pk):
 
 
 def learner_text(request, pk):
-    qs = models.LemmatizedText.objects.filter(
+    qs = LemmatizedText.objects.filter(
         Q(public=True) |
         Q(created_by=request.user) |
         Q(classes__students=request.user) |
@@ -114,7 +113,7 @@ def learner_text(request, pk):
 
 
 def lemma_status(request, pk):
-    lemma = models.LemmatizedText.objects.get(pk=pk)
+    lemma = LemmatizedText.objects.get(pk=pk)
     status = lemma.completed
     length = lemma.token_count()
     return JsonResponse({"status": status, "len": length})
@@ -127,11 +126,9 @@ class HandoutView(PDFResponseMixin, DetailView):
     inline = True
 
     def get_queryset(self):
-        return models.LemmatizedText.objects.all()
+        return LemmatizedText.objects.all()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        data = self.object.data
-        nodes = LatticeNode.objects.filter(pk__in=[token["node"] for token in data])  # .order_by("label")
-        context["words"] = nodes
+        context["glossary"] = self.object.transform_data_to_glossary()
         return context


### PR DESCRIPTION
This PR adds the `pdf-service` to docker, which is required to generate a handout in the learner view, and fixes the handout using the new models. Note that this piece can probably be replaced with a simpler method of generating PDFs, but for now just trying to align with what is running in dev/prod.