### PR TITLE
fix quick add

### DIFF
--- a/hedera/api.py
+++ b/hedera/api.py
@@ -174,10 +174,13 @@ class LemmatizationFormLookupAPI(APIView):
     def get_data(self):
         form = self.kwargs.get("form")
         lang = self.kwargs.get("lang")
+
         # gets list of forms
         forms = FormToLemma.objects.filter(lang=lang, form=form)
         if not forms:
-            forms = FormToLemma.objects.filter(lang=lang, form=form.lower())
+            language_service = SUPPORTED_LANGUAGES[lang].service
+            form_normalized = language_service.normalize(form)
+            forms = FormToLemma.objects.filter(lang=lang, form=form_normalized)
         lemma_list = [form.get_lemma() for form in forms]
         sorted_lemma_list = (sorted(lemma_list, key=lambda i: i["rank"]))
         data = {

--- a/hedera/api.py
+++ b/hedera/api.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import sys
 import traceback
 

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -41,6 +41,12 @@ class BaseService(object):
         """
         raise NotImplementedError("Must provide implementation on a per service basis.")
 
+    def normalize(self, word):
+        """
+        Define a normalization strategy for the language. By default returns the word unchanged.
+        """
+        return word
+
 
 class HttpService(BaseService):
     ENDPOINT = ""

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -87,6 +87,15 @@ class LatinService(BaseService):
             lemmas = lookup_form(word_normalized.lower(), "lat")
         return lemmas
 
+    def normalize(self, word):
+        """
+        For Latin, normalized words are lowercased and macrons are removed.
+        """
+        word = word.lower()
+        if has_macron(word):
+            word = strip_macrons(word)
+        return word
+
 
 class LatinTokenizer(Tokenizer):
     """Latin tokenizer.

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -42,7 +42,9 @@ export default {
   },
   fetchNode: (id, cb) => axios.get(`/lattices/${id}.json`).then((r) => cb(r.data)),
   fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
-  fetchLemmasByForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+  fetchLemmasByForm: (lang, form, cb) => {
+    return axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data));
+  },
   fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
   updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
@@ -66,9 +68,16 @@ export default {
   vocabEntryEdit: (id, headword, gloss, cb) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, gloss }).then((r) => cb(r.data)),
   vocabEntryDelete: (id, cb) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`).then((r) => cb(r.data)),
   fetchPersonalVocabLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
-  createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, cb) => axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, {
-    headword, definition, familiarity, vocabulary_list_id: vocabularyListId, lang,
-  }).then((r) => cb(r.data)),
+  createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, lemma_id, cb) => {
+    const payload = {
+      headword,
+      definition,
+      familiarity,
+      vocabulary_list_id: vocabularyListId,
+      lang,
+      lemma_id,
+    };
+    return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data))},
   fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),
   updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
   deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -42,7 +42,7 @@ export default {
   },
   fetchNode: (id, cb) => axios.get(`/lattices/${id}.json`).then((r) => cb(r.data)),
   fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
-  fetchLemmasByForm: (lang, form, cb) => { axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)) },
+  fetchLemmasByForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
   fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
   updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
@@ -75,7 +75,8 @@ export default {
       lang,
       lemmaId,
     };
-    return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data))},
+    return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data));
+  },
   fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),
   updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
   deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -42,9 +42,7 @@ export default {
   },
   fetchNode: (id, cb) => axios.get(`/lattices/${id}.json`).then((r) => cb(r.data)),
   fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
-  fetchLemmasByForm: (lang, form, cb) => {
-    return axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data));
-  },
+  fetchLemmasByForm: (lang, form, cb) => { axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)) },
   fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
   updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
@@ -68,14 +66,14 @@ export default {
   vocabEntryEdit: (id, headword, gloss, cb) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, gloss }).then((r) => cb(r.data)),
   vocabEntryDelete: (id, cb) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`).then((r) => cb(r.data)),
   fetchPersonalVocabLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
-  createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, lemma_id, cb) => {
+  createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
     const payload = {
       headword,
       definition,
       familiarity,
       vocabulary_list_id: vocabularyListId,
       lang,
-      lemma_id,
+      lemmaId,
     };
     return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data))},
   fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -73,7 +73,7 @@ export default {
       familiarity,
       vocabulary_list_id: vocabularyListId,
       lang,
-      lemmaId,
+      lemma_id: lemmaId,
     };
     return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data));
   },

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -257,7 +257,7 @@
 
         // Get headword from database if it isn't already in state
         if (!Object.hasOwn(this.$store.state.forms, this.headword)) {
-          const newLemma = await this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
+          await this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
             form: this.headword,
             lang: this.vocabularyListItem.lang,
           });

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -54,34 +54,22 @@
       </div>
       <div class="lemma-options-container" :style="showLemmaOptionsList">
         <label for="lemma-select">Linked definition</label>
-        <select
-          id="lemma-select"
-          v-model="lemmaId"
-          @change="onSelect"
-          aria-label="Suggested definition List"
+        <div
+          v-for="lemma in lemmaOptions"
+          :key="lemma.pk"
         >
-          <option
-            id="lemma-options"
-            v-for="lemma in lemmaOptions"
-            :key="lemma.pk"
+          <input
+            type="radio"
+            v-model="lemmaId"
+            @change="onSelect"
             :value="lemma.pk"
+            :id="`lemma-option-${lemma.pk}`"
           >
-            <div>
-              <span
-                class="lemma-label"
-                :value="lemma.label"
-                aria-label="headword"
-                >{{ lemma.label.replace(/[0-9]/g, "") }} -
-              </span>
-              <span
-                class="lemma-gloss"
-                :value='(lemma.glosses.length) ? lemma.glosses[0].gloss : ""'
-                aria-label="gloss"
-                >{{ (lemma.glosses.length) ? lemma.glosses[0].gloss : "" }}</span
-              >
-            </div>
-          </option>
-        </select>
+          <label :for="`lemma-option-${lemma.pk}`">
+            <span class="lemma-label" aria-label="headword">{{ lemma.label.replace(/[0-9]/g, "") }}</span>
+             - <span class="lemma-gloss" aria-label="gloss">{{ (lemma.glosses.length) ? lemma.glosses[0].gloss : "" }}</span>
+          </label>
+        </div>
       </div>
       <button
         type="submit"
@@ -195,11 +183,12 @@
           vocabularyListId: vocabularyListItem.id,
           familiarity: this.familiarityRating,
           lang: vocabularyListItem.lang,
-          lemma_id: null,
+          lemmaId: null,
         };
         if (this.lemmaId) {
-          newEntryData.lemma_id = this.lemmaId;
+          newEntryData.lemmaId = this.lemmaId;
         }
+        console.log(newEntryData);
         await this.$store.dispatch(CREATE_PERSONAL_VOCAB_ENTRY, newEntryData);
 
         if (this.$store.state.personalVocabAdded) {
@@ -232,7 +221,7 @@
       },
       setFocus() {
         this.$nextTick(() => {
-          this.$refs.select.focus();
+          // this.$refs.select.focus();
         });
       },
       // method function for parent components to reset the form when modal is closed

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -111,7 +111,6 @@
   import {
     FETCH_PERSONAL_VOCAB_LANG_LIST,
     CREATE_PERSONAL_VOCAB_ENTRY,
-    FETCH_LATTICE_NODES_BY_HEADWORD,
     RESET_LATTICE_NODES_BY_HEADWORD,
     SET_LANGUAGE_PREF,
     FETCH_SUPPORTED_LANG_LIST,
@@ -157,7 +156,7 @@
         vocabularyListItem: null,
         headword: null,
         definition: null,
-        errorMessage: "An error has occurred. The entry could not be added.",
+        errorMessage: 'An error has occurred. The entry could not be added.',
         lemmaOptions: [],
         lemmaId: null,
         latticeNodeId: null,
@@ -175,7 +174,7 @@
       resetLatticeNodeId() {
         this.latticeNodeId = null;
       },
-      /* 
+      /*
       Handle form submission. This should add a new vocab entry and link it
       to the selected lemma.
        */
@@ -196,7 +195,7 @@
           vocabularyListId: vocabularyListItem.id,
           familiarity: this.familiarityRating,
           lang: vocabularyListItem.lang,
-          lemma_id: null
+          lemma_id: null,
         };
         if (this.lemmaId) {
           newEntryData.lemma_id = this.lemmaId;
@@ -253,7 +252,7 @@
       async getHeadword() {
         console.log(`!${this.headword}:\tNew getHeadword event`);
         // Don't do anything if headword is empty
-        if (this.headword == "") {
+        if (this.headword === '') {
           return null;
         }
 
@@ -267,21 +266,22 @@
         }
 
         // Get the fetched lemmas from the forms in state
-        // TODO: there is a race condition happening here because state is 
+        // TODO: there is a race condition happening here because state is
         // being accessed before it has been modified if you type too fast.
         try {
           this.lemmaOptions = this.stateForms[this.headword].lemmas;
-        } catch(error) {
-          "This is fine actually? It'll keep trying to access state until it succeeds.";
+        } catch (error) {
+          "This is fine actually? It'll keep trying to access state until it succeeds."; // eslint-disable-line
         }
         // sets first lemma option as the default in select options
         if (this.lemmaOptions.length) {
           const { glosses, pk } = this.lemmaOptions[0];
           this.lemmaId = pk;
-          this.definition = glosses.length ? glosses[0].gloss : "";
+          this.definition = glosses.length ? glosses[0].gloss : '';
         }
+        return 0;
       },
-      /* 
+      /*
       When a lemma is selected, update component variables accordingly
        */
       async onSelect(event) {
@@ -330,7 +330,7 @@
       },
       // gives access to the state store of forms
       stateForms() {
-        const forms = this.$store.state.forms;
+        const { forms } = this.$store.state;
         return forms;
       },
       showLatticeNodeList() {
@@ -339,17 +339,17 @@
         }
         return {};
       },
-      /* 
+      /*
       If there are no lemma options to display, set the style of the container
       to display: none;
        */
       showLemmaOptionsList() {
-        if(!this.lemmaOptions.length) {
+        if (!this.lemmaOptions.length) {
           return { display: 'none' };
         } else {
           return {};
         }
-      }
+      },
     },
   };
 </script>

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -286,12 +286,12 @@
        */
       async onSelect(event) {
         if (!Object.hasOwn(this.$store.state.lemmas, event.target.value)) {
-          await this.$store.dispatch(FETCH_LEMMA, { id: event.target.value});
+          await this.$store.dispatch(FETCH_LEMMA, { id: event.target.value });
         }
         const lemma = this.$store.state.lemmas[event.target.value];
         this.definition = lemma.glosses[0].gloss;
       },
-    }, 
+    },
     computed: {
       // gives access to the state store of personalVocabLangList
       personalVocabLangList() {
@@ -346,9 +346,8 @@
       showLemmaOptionsList() {
         if (!this.lemmaOptions.length) {
           return { display: 'none' };
-        } else {
-          return {};
         }
+        return {};
       },
     },
   };

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -107,7 +107,6 @@
     FETCH_LEMMA,
   } from '../../constants';
   import FamiliarityRating from '../../modules/FamiliarityRating.vue';
-  import debounce from 'lodash.debounce';
 
   export default {
     components: { FamiliarityRating },

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -107,6 +107,7 @@
     FETCH_LEMMA,
   } from '../../constants';
   import FamiliarityRating from '../../modules/FamiliarityRating.vue';
+  import debounce from 'lodash.debounce';
 
   export default {
     components: { FamiliarityRating },
@@ -188,7 +189,6 @@
         if (this.lemmaId) {
           newEntryData.lemmaId = this.lemmaId;
         }
-        console.log(newEntryData);
         await this.$store.dispatch(CREATE_PERSONAL_VOCAB_ENTRY, newEntryData);
 
         if (this.$store.state.personalVocabAdded) {
@@ -256,7 +256,7 @@
         // TODO: there is a race condition happening here because state is
         // being accessed before it has been modified if you type too fast.
         try {
-          this.lemmaOptions = this.stateForms[this.headword].lemmas;
+          this.lemmaOptions = this.$store.state.forms[this.headword].lemmas;
         } catch (error) {
           "This is fine actually? It'll keep trying to access state until it succeeds."; // eslint-disable-line
         }
@@ -296,29 +296,6 @@
           return found;
         });
         return formattedPersonalVocabList;
-      },
-      // filters lattice node to exclude parent data for simplier UI in LatticeNode component
-      latticeNode() {
-        const nodes = this.$store.state.latticeNodes || [];
-        if (!nodes.length) return null;
-        const formatedNodes = nodes.map((node) => {
-          const {
-            canonical, definition, label, lemmas, pk,
-          } = node;
-          return {
-            canonical,
-            definition,
-            label,
-            lemmas,
-            pk,
-          };
-        });
-        return formatedNodes;
-      },
-      // gives access to the state store of forms
-      stateForms() {
-        const { forms } = this.$store.state;
-        return forms;
       },
       showLatticeNodeList() {
         if (!this.latticeNode) {

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -250,7 +250,6 @@
       headword as a lemma form. Runs on input to the headword field.
        */
       async getHeadword() {
-        console.log(`!${this.headword}:\tNew getHeadword event`);
         // Don't do anything if headword is empty
         if (this.headword === '') {
           return null;
@@ -262,7 +261,6 @@
             form: this.headword,
             lang: this.vocabularyListItem.lang,
           });
-          console.log(`${this.headword}:\tpromise resolved to ${newLemma}`);
         }
 
         // Get the fetched lemmas from the forms in state

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -79,7 +79,9 @@ export default {
   ),
   [FETCH_NODE]: ({ commit }, { id }) => api.fetchNode(id, (data) => commit(FETCH_NODE, data)),
   [FETCH_LEMMA]: ({ commit }, { id }) => api.fetchLemma(id, (data) => commit(FETCH_LEMMA, data)),
-  [FETCH_LEMMAS_BY_FORM]: ({ commit }, { lang, form }) => api.fetchLemmasByForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_FORM, data)),
+  [FETCH_LEMMAS_BY_FORM]: ({ commit }, { lang, form }) => {
+    return api.fetchLemmasByForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_FORM, data));
+  },
   [UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, lemmaId, glossIds, resolved }) => {
     // Fetch the most recent lemma data
     api
@@ -106,10 +108,10 @@ export default {
       .fetchPersonalVocabLangList(cb)
       .catch(logoutOnError(commit));
   },
-  [CREATE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang }) => {
+  [CREATE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemma_id }) => {
     const cb = (data) => commit(CREATE_PERSONAL_VOCAB_ENTRY, data.data);
     return api
-      .createPersonalVocabEntry(headword, definition, vocabularyListId, familiarity, lang, cb)
+      .createPersonalVocabEntry(headword, definition, vocabularyListId, familiarity, lang, lemma_id, cb)
       .catch(logoutOnError(commit));
   },
   [FETCH_LATTICE_NODES_BY_HEADWORD]: ({ commit }, { headword, lang }) => {

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -79,9 +79,7 @@ export default {
   ),
   [FETCH_NODE]: ({ commit }, { id }) => api.fetchNode(id, (data) => commit(FETCH_NODE, data)),
   [FETCH_LEMMA]: ({ commit }, { id }) => api.fetchLemma(id, (data) => commit(FETCH_LEMMA, data)),
-  [FETCH_LEMMAS_BY_FORM]: ({ commit }, { lang, form }) => {
-    return api.fetchLemmasByForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_FORM, data));
-  },
+  [FETCH_LEMMAS_BY_FORM]: ({ commit }, { lang, form }) => api.fetchLemmasByForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_FORM, data)),
   [UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, lemmaId, glossIds, resolved }) => {
     // Fetch the most recent lemma data
     api
@@ -108,10 +106,10 @@ export default {
       .fetchPersonalVocabLangList(cb)
       .catch(logoutOnError(commit));
   },
-  [CREATE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemma_id }) => {
+  [CREATE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
     const cb = (data) => commit(CREATE_PERSONAL_VOCAB_ENTRY, data.data);
     return api
-      .createPersonalVocabEntry(headword, definition, vocabularyListId, familiarity, lang, lemma_id, cb)
+      .createPersonalVocabEntry(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
       .catch(logoutOnError(commit));
   },
   [FETCH_LATTICE_NODES_BY_HEADWORD]: ({ commit }, { headword, lang }) => {

--- a/vocab_list/models.py
+++ b/vocab_list/models.py
@@ -413,7 +413,12 @@ class PersonalVocabularyListEntry(AbstractVocabListEntry):
         order_with_respect_to = "vocabulary_list"
 
     def data(self):
-        return super().data(familiarity=self.familiarity, lemma_id=self.lemma_id, lemma=self.lemma.lemma)
+        output = {}
+        output["familiarity"] = self.familiarity
+        if self.lemma:
+            output["lemma_id"] = self.lemma_id,
+            output["lemma"] = self.lemma.lemma
+        return super().data(**output)
 
     def familiarity_range(self):
         """hack for template iteration"""


### PR DESCRIPTION
This commit fixes the quick add component to work without the lattice. Quick add prompts users for a headword and definition, and as they type the headword, a set of radio button options appears with lemmas to connect to. The selected lemma is linked to the vocab list entry when it is added to the list.

This commit also makes some changes to the api and models in django. This improves error logging on the quick add endpoint and fixes an error that would occur when the `data` method was called on vocab list entries that didn't have an associated lemma.