### PR TITLE
fix personal vocab edit

### DIFF
--- a/vocab_list/models.py
+++ b/vocab_list/models.py
@@ -419,7 +419,7 @@ class PersonalVocabularyListEntry(AbstractVocabListEntry):
         output = {}
         output["familiarity"] = self.familiarity
         if self.lemma:
-            output["lemma_id"] = self.lemma_id,
+            output["lemma_id"] = self.lemma_id
             output["lemma"] = self.lemma.lemma
         return super().data(**output)
 


### PR DESCRIPTION
Remove comma in `personalvocabentries` model because the `lemma_id` was being transformed into a tuple.