### PR TITLE
(docs) Fix example for running local tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ Here's one way to run them, using the containerized app, which is already config
 ```
 docker compose up -d postgres redis
 # make sure postgres and redis are available, then run:
-docker compose run --rm --no-deps -e DJANGO_SETTINGS_MODULE=hedera.test_settings django python manage.py test
+docker compose run --rm --no-deps --service-ports -e DJANGO_SETTINGS_MODULE=hedera.test_settings django python manage.py test
 ```
 
 You can also run them locally (i.e. not in a container) if you have the appropriate python environment configured. For instance:


### PR DESCRIPTION
Adds `--service-ports` to `docker compose run` command for django unit tests so that debugger port is exposed for debug client connections.

## Context

During the 10/25/2022 `#dojo` session we ran into a problem with local debug config that prevented connecting the VS Code debugger (client) to the `debugpy` server running in the app under test.

This appears to have been due to this quirk of the `run` command:
> The second difference is that the `docker compose run` command does not create any of the ports specified in the service configuration. This prevents port collisions with already-open ports. If you do want the service’s ports to be created and mapped to the host, specify the `--service-ports`
> (cf https://docs.docker.com/engine/reference/commandline/compose_run/#description)

