### PR TITLE
Fix familiarity in learner view

### DIFF
--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -46,11 +46,15 @@ export default {
       .fetchVocabLists(state.text.lang, (data) => commit(FETCH_VOCAB_LISTS, data.data))
       .catch(logoutOnError(commit));
   },
-  [CREATE_VOCAB_ENTRY]: ({ commit, state }, { lemmaId, familiarity, headword, definition }) => {
-    const cb = (data) => commit(FETCH_PERSONAL_VOCAB_LIST, data.data);
-    api
-      .updatePersonalVocabList(state.text.id, lemmaId, familiarity, headword, definition, null, null, cb)
-      .catch(logoutOnError(commit));
+  [CREATE_VOCAB_ENTRY]: async ({ commit, state }, { lemmaId, familiarity, headword, definition }) => {
+    // TODO: Make DRY with updateVocabEntry
+    const { response, data } = await api
+      .updatePersonalVocabList(state.text.id, lemmaId, familiarity, headword, definition, null, null);
+    if (response && response.status >= 400) {
+      return response;
+    }
+    commit(FETCH_PERSONAL_VOCAB_LIST, data);
+    return null;
   },
   // eslint-disable-next-line max-len
   [UPDATE_VOCAB_ENTRY]: async ({ commit, state }, { entryId, familiarity, headword, definition, lang = null, lemmaId }) => {


### PR DESCRIPTION
This PR fixes the text learner view familiarity interaction. When changing a familiarity rating for new words that are not included in the users personal vocabulary list the UI would not update the ratings for the newly changed/added word when navigating away and back to the previously changed/added word.

Note: the updated code is very similar to how `UPDATE_VOCAB_ENTRY` actions is interacting with the `updatePersonalVocabList` api. We will need to optimize the code to conform to DRY principles