### PR TITLE
Learner Selected Word Reveal Gloss

### DIFF
--- a/static/src/js/app/Learner.vue
+++ b/static/src/js/app/Learner.vue
@@ -373,8 +373,10 @@
     }
   }
   &.revealable-gloss {
-    opacity: 0;
-    &.show {
+    .gloss {
+      opacity: 0;
+    }
+    &.show .gloss {
       opacity: 1;
     }
   }


### PR DESCRIPTION
This PR updates the learner view of the selected word so that the dictionary entry is always displayed, and only the gloss is hidden by default.

**Default view when clicking on a word in the text:**

![selected-word-default](https://user-images.githubusercontent.com/1165361/200043305-7db9743a-0ccd-40ce-b300-1a1ca22e9e37.png)

**With the gloss revealed:**

![selected-word-gloss-revealed](https://user-images.githubusercontent.com/1165361/200043315-ddbec88d-72dc-4550-849c-191fa6c3f3f3.png)
