### PR TITLE
fix key error in API when edit happens

### DIFF
--- a/hedera/api.py
+++ b/hedera/api.py
@@ -215,11 +215,15 @@ class LemmatizationAPI(APIView):
                 token.update(lemma.gloss_data())
             if vocablist_id is not None:
                 vocab_entry = vocablist.entries.filter(lemma_id=token["lemma_id"])
+                # check if token has resolved key:value pair before comparison further down so there isnt key error
+                resolved = False
+                if "resolved" in token.keys():
+                    resolved = token["resolved"]
                 if vocablist_id == "personal":
                     # Note: assumes that the vocab can successfully link to a lemma - not accounting for NULL Values
                     familarity = list(vocab_entry.values_list("familiarity", flat=True))
-                    token["familiarity"] = token["resolved"] and familarity and familarity[0]
-                token["inVocabList"] = token["resolved"] and vocab_entry.exists()
+                    token["familiarity"] = resolved and familarity and familarity[0]
+                token["inVocabList"] = resolved and vocab_entry.exists()
         return data
 
     def get_data(self):


### PR DESCRIPTION
### This PR fixes the bug #460 which would reset known/unknown words when text is compared to a personal vocab list.

This bug occurs when text is edited. The new tokens don't have "resolved" `key:value` pair in the newly created dict. This would throw a key error.
- Added conditional to check if dict has "resolved" key and default value for "resolved" since it is used for comparison further down in the code.
#### Note:
The newly calculated percentage don't match because of another bug where edited text have extra blank tokens