### PR TITLE
Tidy vuex

### DIFF
--- a/static/src/js/app/App.vue
+++ b/static/src/js/app/App.vue
@@ -17,11 +17,11 @@
 </template>
 <script>
   import {
-    FETCH_TOKENS,
-    FETCH_VOCAB_LISTS,
-    FETCH_TEXT,
-    FETCH_ME,
-    FETCH_PERSONAL_VOCAB_LIST, FETCH_BOOKMARKS,
+    LEMMATIZED_TEXT_FETCH_TOKENS,
+    VOCAB_LIST_LIST,
+    LEMMATIZED_TEXT_FETCH,
+    PROFILE_FETCH,
+    PERSONAL_VOCAB_LIST_FETCH, BOOKMARK_LIST,
   } from './constants';
 
   import LemmatizedText from './modules/LemmatizedText.vue';
@@ -38,16 +38,16 @@
       BookmarkTextButton,
     },
     created() {
-      this.$store.dispatch(FETCH_ME);
-      this.$store.dispatch(FETCH_BOOKMARKS);
+      this.$store.dispatch(PROFILE_FETCH);
+      this.$store.dispatch(BOOKMARK_LIST);
     },
     watch: {
       textId: {
         immediate: true,
         handler() {
-          this.$store.dispatch(FETCH_TEXT, { id: this.textId })
+          this.$store.dispatch(LEMMATIZED_TEXT_FETCH, { id: this.textId })
             .then(() => {
-              this.$store.dispatch(FETCH_VOCAB_LISTS);
+              this.$store.dispatch(VOCAB_LIST_LIST);
             });
         },
       },
@@ -55,9 +55,9 @@
         immediate: true,
         handler() {
           if (this.selectedVocabListId === 'personal') {
-            this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, { lang: this.$store.state.text.lang });
+            this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang: this.$store.state.text.lang });
           }
-          this.$store.dispatch(FETCH_TOKENS, { id: this.textId, vocabListId: this.selectedVocabListId });
+          this.$store.dispatch(LEMMATIZED_TEXT_FETCH_TOKENS, { id: this.textId, vocabListId: this.selectedVocabListId });
         },
       },
     },

--- a/static/src/js/app/Dashboard.vue
+++ b/static/src/js/app/Dashboard.vue
@@ -6,14 +6,14 @@
 </template>
 <script>
   import QuickAddButton from './components/quick-add-button';
-  import { FETCH_ME, FETCH_SUPPORTED_LANG_LIST } from './constants';
+  import { PROFILE_FETCH, SUPPORTED_LANG_LIST_FETCH } from './constants';
   import BookmarkList from './modules/BookmarkList.vue';
 
   export default {
     components: { QuickAddButton, BookmarkList },
     async created() {
-      await this.$store.dispatch(FETCH_ME);
-      await this.$store.dispatch(FETCH_SUPPORTED_LANG_LIST);
+      await this.$store.dispatch(PROFILE_FETCH);
+      await this.$store.dispatch(SUPPORTED_LANG_LIST_FETCH);
     },
   };
 </script>

--- a/static/src/js/app/Learner.vue
+++ b/static/src/js/app/Learner.vue
@@ -105,13 +105,13 @@
 </template>
 <script>
   import {
-    FETCH_TOKENS,
-    FETCH_PERSONAL_VOCAB_LIST,
-    FETCH_TEXT,
+    LEMMATIZED_TEXT_FETCH_TOKENS,
+    PERSONAL_VOCAB_LIST_FETCH,
+    LEMMATIZED_TEXT_FETCH,
     OLD_CREATE_VOCAB_ENTRY,
-    UPDATE_PERSONAL_VOCAB_ENTRY,
-    FETCH_ME,
-    FETCH_BOOKMARKS,
+    PERSONAL_VOCAB_ENTRY_UPDATE,
+    PROFILE_FETCH,
+    BOOKMARK_LIST,
   } from './constants';
 
   import LemmatizedText from './modules/LemmatizedText.vue';
@@ -132,8 +132,8 @@
       BookmarkTextButton,
     },
     created() {
-      this.$store.dispatch(FETCH_ME);
-      this.$store.dispatch(FETCH_BOOKMARKS);
+      this.$store.dispatch(PROFILE_FETCH);
+      this.$store.dispatch(BOOKMARK_LIST);
     },
     data() {
       return {
@@ -147,7 +147,7 @@
       textId: {
         immediate: true,
         handler() {
-          this.$store.dispatch(FETCH_TEXT, { id: this.textId }).then(() => this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, {
+          this.$store.dispatch(LEMMATIZED_TEXT_FETCH, { id: this.textId }).then(() => this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, {
             lang: this.text.lang,
           }));
         },
@@ -155,7 +155,7 @@
       selectedVocabList: {
         immediate: true,
         handler() {
-          this.$store.dispatch(FETCH_TOKENS, {
+          this.$store.dispatch(LEMMATIZED_TEXT_FETCH_TOKENS, {
             id: this.textId,
             personalVocabListId: this.selectedVocabListId,
           });
@@ -180,7 +180,7 @@
 
         this.selectedNodeRating = rating;
         if (this.personalVocabEntry) {
-          this.$store.dispatch(UPDATE_PERSONAL_VOCAB_ENTRY, {
+          this.$store.dispatch(PERSONAL_VOCAB_ENTRY_UPDATE, {
             entryId: this.personalVocabEntry.id,
             familiarity: rating,
             headword: label,

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -128,15 +128,15 @@
   import { VueGoodTable } from 'vue-good-table';
 
   import {
-    FETCH_PERSONAL_VOCAB_LIST,
-    UPDATE_PERSONAL_VOCAB_ENTRY,
-    FETCH_ME,
-    DELETE_PERSONAL_VOCAB_ENTRY,
-    FETCH_LEMMAS_BY_PARTIAL_FORM,
-    FETCH_VOCAB_LIST,
-    DELETE_VOCAB_ENTRY,
-    SET_VOCAB_LIST_TYPE,
-    UPDATE_VOCAB_ENTRY,
+    PERSONAL_VOCAB_LIST_FETCH,
+    PERSONAL_VOCAB_ENTRY_UPDATE,
+    PROFILE_FETCH,
+    PERSONAL_VOCAB_ENTRY_DELETE,
+    FORMS_FETCH_PARTIAL,
+    VOCAB_LIST_FETCH,
+    VOCAB_ENTRY_DELETE,
+    VOCAB_LIST_SET_TYPE,
+    VOCAB_ENTRY_UPDATE,
   } from './constants';
 
   import FamiliarityRating from './modules/FamiliarityRating.vue';
@@ -156,11 +156,11 @@
         immediate: true,
         handler() {
           if (this.personalVocab) {
-            this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, { lang: this.lang });
-            this.$store.dispatch(SET_VOCAB_LIST_TYPE, { vocabListType: 'personal' });
+            this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang: this.lang });
+            this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'personal' });
           } else {
-            this.$store.dispatch(FETCH_VOCAB_LIST, { vocabListId: this.vocabId });
-            this.$store.dispatch(SET_VOCAB_LIST_TYPE, { vocabListType: 'general' });
+            this.$store.dispatch(VOCAB_LIST_FETCH, { vocabListId: this.vocabId });
+            this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'general' });
           }
         },
       },
@@ -168,11 +168,11 @@
         immediate: true,
         handler() {
           if (this.personalVocab) {
-            this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, { lang: this.lang });
-            this.$store.dispatch(SET_VOCAB_LIST_TYPE, { vocabListType: 'personal' });
+            this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang: this.lang });
+            this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'personal' });
           } else {
-            this.$store.dispatch(FETCH_VOCAB_LIST, { vocabListId: this.vocabId });
-            this.$store.dispatch(SET_VOCAB_LIST_TYPE, { vocabListType: 'general' });
+            this.$store.dispatch(VOCAB_LIST_FETCH, { vocabListId: this.vocabId });
+            this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'general' });
           }
         },
       },
@@ -203,7 +203,7 @@
       };
     },
     created() {
-      this.$store.dispatch(FETCH_ME);
+      this.$store.dispatch(PROFILE_FETCH);
       document.addEventListener('keydown', this.onKeyDown);
     },
     beforeDestroy() {
@@ -223,22 +223,22 @@
           return;
         }
         const definition = entry.definition || '';
-        await this.$store.dispatch(UPDATE_PERSONAL_VOCAB_ENTRY, {
+        await this.$store.dispatch(PERSONAL_VOCAB_ENTRY_UPDATE, {
           entryId: entry.id,
           familiarity: rating,
           headword,
           definition,
           lang: this.lang,
         });
-        await this.$store.dispatch(FETCH_PERSONAL_VOCAB_LIST, {
+        await this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, {
           lang: this.lang,
         });
       },
       async deleteVocab(id) {
         if (this.isPersonal) {
-          await this.$store.dispatch(DELETE_PERSONAL_VOCAB_ENTRY, { id });
+          await this.$store.dispatch(PERSONAL_VOCAB_ENTRY_DELETE, { id });
         } else if (this.vocabList.canEdit) {
-          await this.$store.dispatch(DELETE_VOCAB_ENTRY, { id });
+          await this.$store.dispatch(VOCAB_ENTRY_DELETE, { id });
         } else {
           this.makeToast("You don't have permission to delete this", 403);
         }
@@ -267,7 +267,7 @@
           this.editingFields.familiarity = familiarity;
         }
         if (field === 'lemma' && value !== '') {
-          await this.$store.dispatch(FETCH_LEMMAS_BY_PARTIAL_FORM, {
+          await this.$store.dispatch(FORMS_FETCH_PARTIAL, {
             form: value,
             lang: this.lang,
           });
@@ -288,7 +288,7 @@
         } = this.editingFields;
         let response = null;
         if (this.isPersonal) {
-          response = await this.$store.dispatch(UPDATE_PERSONAL_VOCAB_ENTRY, {
+          response = await this.$store.dispatch(PERSONAL_VOCAB_ENTRY_UPDATE, {
             entryId,
             familiarity,
             headword,
@@ -297,7 +297,7 @@
             lemmaId,
           });
         } else {
-          response = await this.$store.dispatch(UPDATE_VOCAB_ENTRY, {
+          response = await this.$store.dispatch(VOCAB_ENTRY_UPDATE, {
             entryId,
             headword,
             definition,

--- a/static/src/js/app/Texts.vue
+++ b/static/src/js/app/Texts.vue
@@ -34,7 +34,7 @@
   import api from './api';
 
   import TextRow from './components/TextRow.vue';
-  import { FETCH_ME } from './constants';
+  import { PROFILE_FETCH } from './constants';
 
   export default {
     components: {
@@ -64,7 +64,7 @@
       },
     },
     created() {
-      this.$store.dispatch(FETCH_ME);
+      this.$store.dispatch(PROFILE_FETCH);
       api.fetchTexts((data) => {
         this.texts = data.data.map((datum) => ({
           ...datum.text,

--- a/static/src/js/app/Vocab.vue
+++ b/static/src/js/app/Vocab.vue
@@ -34,7 +34,7 @@
   import api from './api';
   import VocabularyLemma from './modules/VocabularyLemma.vue';
   import VocabListTable from './components/vocab-list-table';
-  import { FETCH_LEMMA, FETCH_ME } from './constants';
+  import { LEMMA_FETCH, PROFILE_FETCH } from './constants';
 
   export default {
     props: ['vocabId'],
@@ -50,7 +50,7 @@
       };
     },
     created() {
-      this.$store.dispatch(FETCH_ME);
+      this.$store.dispatch(PROFILE_FETCH);
     },
     computed: {
       showToggle() {
@@ -82,7 +82,7 @@
         } else {
           // if primary key provided is not null and not in state, fetch it
           // and assign the result to selected lemma
-          this.$store.dispatch(FETCH_LEMMA, { id: lemmaPK }).then(() => {
+          this.$store.dispatch(LEMMA_FETCH, { id: lemmaPK }).then(() => {
             this.selectedLemma = this.$store.state.lemmas[lemmaPK];
           });
         }

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -9,30 +9,30 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  fetchMe: (cb) => axios.get(`${BASE_URL}me/`).then((r) => cb(r.data)),
-  updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
+  profile_fetch: (cb) => axios.get(`${BASE_URL}me/`).then((r) => cb(r.data)),
+  profile_updateLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
   /* -------------------------------------------------------------------------- */
-  fetchLemmasByForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
-  fetchLemmasByPartialForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+  form_fetch: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+  form_fetchPartial: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Lemma                            */
   /* -------------------------------------------------------------------------- */
-  fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
+  lemma_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  fetchText: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
-  fetchTexts: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
-  fetchTextStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
-  cloneText: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
-  textRetryLemmatization: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
-  textCancelLemmatization: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`).then((r) => cb(r.data)),
-  fetchTokens: (id, vocabList, personalVocabList, cb) => {
+  lemmatizedText_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
+  lemmatizedText_list: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
+  lemmatizedText_fetchStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
+  lemmatizedText_clone: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
+  lemmatizedText_retry: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
+  lemmatizedText_cancel: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`).then((r) => cb(r.data)),
+  lemmatizedText_fetchTokens: (id, vocabList, personalVocabList, cb) => {
     if (!vocabList && !personalVocabList) {
       return axios.get(`${BASE_URL}lemmatized_texts/${id}/`).then((r) => cb(r.data));
     }
@@ -45,7 +45,7 @@ export default {
     }
     return axios.get(`${BASE_URL}lemmatized_texts/${id}/?${qs}`).then((r) => cb(r.data));
   },
-  updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
+  lemmatizedText_updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
       return axios.post(`${BASE_URL}lemmatized_texts/${id}/`, {
         tokenIndex,
@@ -63,20 +63,20 @@ export default {
       resolved,
     }).then((r) => cb(r.data));
   },
-  fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
+  lemmatizedText_fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  fetchBookmarks: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
-  addBookmark: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
-  removeBookmark: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
+  bookmark_list: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
+  bookmark_create: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
+  bookmark_delete: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
-  fetchPersonalVocabList: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
-  updatePersonalVocabList: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
+  personalVocabularyList_fetch: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
+  personalVocabularyList_update: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
     let data = {
       familiarity, headword, definition, lemmaId,
     };
@@ -89,13 +89,13 @@ export default {
     data = { ...data, lemmaId };
     return axios.post(`${BASE_URL}personal_vocab_list/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
   },
-  fetchPersonalVocabLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
+  personalVocabularyList_fetchLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
-  createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
+  personalVocabularyListEntry_delete: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
+  personalVocabularyListEntry_create: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
     const payload = {
       headword,
       definition,
@@ -110,17 +110,17 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
   /* -------------------------------------------------------------------------- */
-  fetchVocabList: (vocabListId) => axios.get(`${BASE_URL}vocab_lists/${vocabListId}`),
-  fetchVocabLists: (lang) => axios.get(`${BASE_URL}vocab_lists/?lang=${lang}`),
+  vocabularyList_fetch: (vocabListId) => axios.get(`${BASE_URL}vocab_lists/${vocabListId}`),
+  vocabularyList_list: (lang) => axios.get(`${BASE_URL}vocab_lists/?lang=${lang}`),
 
   /* -------------------------------------------------------------------------- */
   /*                       vocab_list.VocabularyListEntry                       */
   /* -------------------------------------------------------------------------- */
-  fetchVocabEntries: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
-  linkVocabEntry: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
-  updateVocabEntry: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
-  deleteVocabEntry: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
-  createVocabEntry: (vocabularyListId, headword, definition, lemmaId) => {
+  vocabularyListEntry_list: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
+  vocabularyListEntry_link: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
+  vocabularyListEntry_update: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
+  vocabularyListEntry_delete: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
+  vocabularyListEntry_create: (vocabularyListId, headword, definition, lemmaId) => {
     const payload = {
       headword,
       definition,
@@ -134,7 +134,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */
   /* -------------------------------------------------------------------------- */
-  fetchSupportedLangList: (cb) => axios.get(`${BASE_URL}supported_languages/`).then((r) => cb(r.data)),
+  supportedLangList_fetch: (cb) => axios.get(`${BASE_URL}supported_languages/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*         TODO: Delete these things, ensuring that they are not used.        */

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -26,12 +26,10 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  lemmatizedText_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
-  lemmatizedText_list: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
-  lemmatizedText_fetchStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
-  lemmatizedText_clone: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
-  lemmatizedText_retry: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
   lemmatizedText_cancel: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`).then((r) => cb(r.data)),
+  lemmatizedText_clone: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
+  lemmatizedText_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
+  lemmatizedText_fetchStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
   lemmatizedText_fetchTokens: (id, vocabList, personalVocabList, cb) => {
     if (!vocabList && !personalVocabList) {
       return axios.get(`${BASE_URL}lemmatized_texts/${id}/`).then((r) => cb(r.data));
@@ -45,6 +43,9 @@ export default {
     }
     return axios.get(`${BASE_URL}lemmatized_texts/${id}/?${qs}`).then((r) => cb(r.data));
   },
+  lemmatizedText_fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
+  lemmatizedText_list: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
+  lemmatizedText_retry: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
   lemmatizedText_updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
       return axios.post(`${BASE_URL}lemmatized_texts/${id}/`, {
@@ -63,19 +64,19 @@ export default {
       resolved,
     }).then((r) => cb(r.data));
   },
-  lemmatizedText_fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  bookmark_list: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
   bookmark_create: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
   bookmark_delete: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
+  bookmark_list: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
   personalVocabularyList_fetch: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
+  personalVocabularyList_fetchLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
   personalVocabularyList_update: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
     let data = {
       familiarity, headword, definition, lemmaId,
@@ -89,12 +90,10 @@ export default {
     data = { ...data, lemmaId };
     return axios.post(`${BASE_URL}personal_vocab_list/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
   },
-  personalVocabularyList_fetchLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
 
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  personalVocabularyListEntry_delete: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
   personalVocabularyListEntry_create: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
     const payload = {
       headword,
@@ -106,6 +105,7 @@ export default {
     };
     return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data));
   },
+  personalVocabularyListEntry_delete: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
 
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
@@ -116,10 +116,6 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                       vocab_list.VocabularyListEntry                       */
   /* -------------------------------------------------------------------------- */
-  vocabularyListEntry_list: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
-  vocabularyListEntry_link: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
-  vocabularyListEntry_update: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
-  vocabularyListEntry_delete: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
   vocabularyListEntry_create: (vocabularyListId, headword, definition, lemmaId) => {
     const payload = {
       headword,
@@ -130,6 +126,10 @@ export default {
     }
     return axios.post(`${BASE_URL}vocab_lists/${vocabularyListId}/entries/`, payload);
   },
+  vocabularyListEntry_delete: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
+  vocabularyListEntry_link: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
+  vocabularyListEntry_list: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
+  vocabularyListEntry_update: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
 
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -6,30 +6,32 @@ axios.defaults.xsrfCookieName = 'csrftoken';
 const BASE_URL = '/api/v1/';
 
 export default {
+  /* -------------------------------------------------------------------------- */
+  /*                               hedera.Profile                               */
+  /* -------------------------------------------------------------------------- */
   fetchMe: (cb) => axios.get(`${BASE_URL}me/`).then((r) => cb(r.data)),
-  fetchTexts: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
+  updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*                             lemmatization.Form                             */
+  /* -------------------------------------------------------------------------- */
+  fetchLemmasByForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+  fetchLemmasByPartialForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*                             lemmatization.Lemma                            */
+  /* -------------------------------------------------------------------------- */
+  fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*                       lemmatized_text.LemmatizedText                       */
+  /* -------------------------------------------------------------------------- */
   fetchText: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
+  fetchTexts: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
   fetchTextStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
   cloneText: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
   textRetryLemmatization: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
   textCancelLemmatization: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`).then((r) => cb(r.data)),
-  fetchPersonalVocabList: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
-  updatePersonalVocabList: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
-    let data = {
-      familiarity, headword, definition, lemmaId,
-    };
-    if (lang !== null && entryId !== null) {
-      return axios.post(`${BASE_URL}personal_vocab_list/${entryId}/?lang=${lang}`, data).then((r) => r.data).catch((error) => error);
-    }
-    if (entryId !== null) {
-      return axios.post(`${BASE_URL}personal_vocab_list/${entryId}/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
-    }
-    data = { ...data, lemmaId };
-    return axios.post(`${BASE_URL}personal_vocab_list/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
-  },
-  fetchVocabList: (vocabListId) => axios.get(`${BASE_URL}vocab_lists/${vocabListId}`),
-  fetchVocabLists: (lang) => axios.get(`${BASE_URL}vocab_lists/?lang=${lang}`),
-  fetchVocabEntries: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
   fetchTokens: (id, vocabList, personalVocabList, cb) => {
     if (!vocabList && !personalVocabList) {
       return axios.get(`${BASE_URL}lemmatized_texts/${id}/`).then((r) => cb(r.data));
@@ -43,11 +45,6 @@ export default {
     }
     return axios.get(`${BASE_URL}lemmatized_texts/${id}/?${qs}`).then((r) => cb(r.data));
   },
-  fetchNode: (id, cb) => axios.get(`/lattices/${id}.json`).then((r) => cb(r.data)),
-  fetchLemma: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
-  fetchLemmasByForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
-  fetchLemmasByPartialForm: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
-  fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
   updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
     if (vocabList === null) {
       return axios.post(`${BASE_URL}lemmatized_texts/${id}/`, {
@@ -66,10 +63,38 @@ export default {
       resolved,
     }).then((r) => cb(r.data));
   },
-  linkVocabEntry: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
-  updateVocabEntry: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
-  deleteVocabEntry: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
+  fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*                   lemmatized_text.LemmatizedTextBookmark                   */
+  /* -------------------------------------------------------------------------- */
+  fetchBookmarks: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
+  addBookmark: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
+  removeBookmark: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
+
+  /* -------------------------------------------------------------------------- */
+  /*                      vocab_list.PersonalVocabularyList                     */
+  /* -------------------------------------------------------------------------- */
+  fetchPersonalVocabList: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
+  updatePersonalVocabList: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
+    let data = {
+      familiarity, headword, definition, lemmaId,
+    };
+    if (lang !== null && entryId !== null) {
+      return axios.post(`${BASE_URL}personal_vocab_list/${entryId}/?lang=${lang}`, data).then((r) => r.data).catch((error) => error);
+    }
+    if (entryId !== null) {
+      return axios.post(`${BASE_URL}personal_vocab_list/${entryId}/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
+    }
+    data = { ...data, lemmaId };
+    return axios.post(`${BASE_URL}personal_vocab_list/?text=${textId}`, data).then((r) => r.data).catch((error) => error);
+  },
   fetchPersonalVocabLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*                   vocab_list.PersonalVocabularyListEntry                   */
+  /* -------------------------------------------------------------------------- */
+  deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
   createPersonalVocabEntry: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
     const payload = {
       headword,
@@ -81,6 +106,20 @@ export default {
     };
     return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data));
   },
+
+  /* -------------------------------------------------------------------------- */
+  /*                          vocab_list.VocabularyList                         */
+  /* -------------------------------------------------------------------------- */
+  fetchVocabList: (vocabListId) => axios.get(`${BASE_URL}vocab_lists/${vocabListId}`),
+  fetchVocabLists: (lang) => axios.get(`${BASE_URL}vocab_lists/?lang=${lang}`),
+
+  /* -------------------------------------------------------------------------- */
+  /*                       vocab_list.VocabularyListEntry                       */
+  /* -------------------------------------------------------------------------- */
+  fetchVocabEntries: (id, cb) => axios.get(`${BASE_URL}vocab_lists/${id}/entries/`).then((r) => cb(r.data)),
+  linkVocabEntry: (id, lemmaId) => axios.post(`${BASE_URL}vocab_entries/${id}/link/`, { lemma_id: lemmaId }),
+  updateVocabEntry: (id, headword, definition) => axios.post(`${BASE_URL}vocab_entries/${id}/edit/`, { headword, definition }),
+  deleteVocabEntry: (id) => axios.post(`${BASE_URL}vocab_entries/${id}/delete/`),
   createVocabEntry: (vocabularyListId, headword, definition, lemmaId) => {
     const payload = {
       headword,
@@ -91,11 +130,15 @@ export default {
     }
     return axios.post(`${BASE_URL}vocab_lists/${vocabularyListId}/entries/`, payload);
   },
-  fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),
-  updateMeLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
-  deletePersonalVocabEntry: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
-  fetchBookmarks: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
-  addBookmark: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
-  removeBookmark: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
+
+  /* -------------------------------------------------------------------------- */
+  /*                            Not accessing a model                           */
+  /* -------------------------------------------------------------------------- */
   fetchSupportedLangList: (cb) => axios.get(`${BASE_URL}supported_languages/`).then((r) => cb(r.data)),
+
+  /* -------------------------------------------------------------------------- */
+  /*         TODO: Delete these things, ensuring that they are not used.        */
+  /* -------------------------------------------------------------------------- */
+  fetchNode: (id, cb) => axios.get(`/lattices/${id}.json`).then((r) => cb(r.data)),
+  fetchLatticeNodes: (headword, lang, cb) => axios.get(`${BASE_URL}lattice_nodes/?headword=${headword}&lang=${lang}`).then((r) => cb(r.data)),
 };

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -98,14 +98,14 @@
 
 <script>
   import {
-    FETCH_PERSONAL_VOCAB_LANG_LIST,
-    CREATE_PERSONAL_VOCAB_ENTRY,
-    SET_LANGUAGE_PREF,
-    FETCH_SUPPORTED_LANG_LIST,
-    FETCH_ME,
-    FETCH_LEMMAS_BY_FORM,
-    FETCH_LEMMA,
-    CREATE_VOCAB_ENTRY,
+    PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+    PERSONAL_VOCAB_ENTRY_CREATE,
+    PROFILE_SET_LANGUAGE_PREF,
+    SUPPORTED_LANG_LIST_FETCH,
+    PROFILE_FETCH,
+    FORMS_FETCH,
+    LEMMA_FETCH,
+    VOCAB_ENTRY_CREATE,
   } from '../../constants';
   import FamiliarityRating from '../../modules/FamiliarityRating.vue';
 
@@ -114,13 +114,13 @@
     props: ['currentLangTab'],
     // on creation of the dom element fetch the list of langauages/ids the user has in their personal vocab list
     async created() {
-      await this.$store.dispatch(FETCH_PERSONAL_VOCAB_LANG_LIST);
+      await this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH_LANG_LIST);
       /**
       need to fetch supported languages and profile due to django templates causing vuex state to not persistant
       ex: navigation and personal vocab templates
        */
-      await this.$store.dispatch(FETCH_ME);
-      await this.$store.dispatch(FETCH_SUPPORTED_LANG_LIST);
+      await this.$store.dispatch(PROFILE_FETCH);
+      await this.$store.dispatch(SUPPORTED_LANG_LIST_FETCH);
       // set pref language for personal vocab lists
       if (this.isPersonal) {
         if (this.$store.state.me && this.$store.state.me.lang) {
@@ -200,9 +200,9 @@
         if (this.vocabListType === 'personal') {
           newEntryData.familiarity = this.familiarityRating;
           newEntryData.lang = vocabularyListItem.lang;
-          await this.$store.dispatch(CREATE_PERSONAL_VOCAB_ENTRY, newEntryData);
+          await this.$store.dispatch(PERSONAL_VOCAB_ENTRY_CREATE, newEntryData);
         } else {
-          await this.$store.dispatch(CREATE_VOCAB_ENTRY, newEntryData);
+          await this.$store.dispatch(VOCAB_ENTRY_CREATE, newEntryData);
         }
 
         // Clear component variables on successful submit, or report an error
@@ -223,7 +223,7 @@
             (ele) => ele.lang === vocabularyListItem.lang,
           );
           if (prefLang && prefLang.lang !== this.$store.state.me.lang) {
-            await this.$store.dispatch(SET_LANGUAGE_PREF, {
+            await this.$store.dispatch(PROFILE_SET_LANGUAGE_PREF, {
               lang: prefLang.lang,
             });
           }
@@ -269,7 +269,7 @@
         // Get headword from database if it isn't already in state
         // Note: Node v14.X does not have a function called Object.hasOwn so converted to hasOwnProperty
         if (!Object.prototype.hasOwnProperty.call(this.$store.state.forms, this.headword)) {
-          await this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
+          await this.$store.dispatch(FORMS_FETCH, {
             form: this.headword,
             lang: this.vocabularyListLang,
           });
@@ -295,7 +295,7 @@
       async onSelect(event) {
         // Note: Node v14.X does not have a function called Object.hasOwn so converted to hasOwnProperty
         if (!Object.prototype.hasOwnProperty.call(this.$store.state.lemmas, event.target.value)) {
-          await this.$store.dispatch(FETCH_LEMMA, { id: event.target.value });
+          await this.$store.dispatch(LEMMA_FETCH, { id: event.target.value });
         }
         const lemma = this.$store.state.lemmas[event.target.value];
         this.definition = lemma.glosses.length ? lemma.glosses[0].gloss : '';

--- a/static/src/js/app/components/vocab-list-select/VocabListSelect.vue
+++ b/static/src/js/app/components/vocab-list-select/VocabListSelect.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-  import { SET_VOCAB_LIST } from '../../constants';
+  import { VOCAB_LIST_SET } from '../../constants';
   import VocabListEntry from './VocabListEntry.vue';
   import VocabListSelectedEntry from './VocabListSelectedEntry.vue';
 
@@ -32,7 +32,7 @@
     },
     methods: {
       onSelect(id) {
-        this.$store.dispatch(SET_VOCAB_LIST, id).then(() => { this.open = false; });
+        this.$store.dispatch(VOCAB_LIST_SET, id).then(() => { this.open = false; });
       },
     },
   };

--- a/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
+++ b/static/src/js/app/components/vocab-list-select/VocabListSelectedEntry.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-  import { TOGGLE_SHOW_IN_VOCAB_LIST, SET_VOCAB_LIST } from '../../constants';
+  import { LEMMATIZED_TEXT_SHOW_KNOWN, VOCAB_LIST_SET } from '../../constants';
 
   export default {
     props: ['vocabList'],
@@ -46,11 +46,11 @@
     },
     methods: {
       toggleKnown() {
-        this.$store.dispatch(TOGGLE_SHOW_IN_VOCAB_LIST);
+        this.$store.dispatch(LEMMATIZED_TEXT_SHOW_KNOWN);
       },
       closeVocabList() {
         console.log('hhhh');
-        this.$store.dispatch(SET_VOCAB_LIST, { id: null });
+        this.$store.dispatch(VOCAB_LIST_SET, { id: null });
       },
     },
   };

--- a/static/src/js/app/constants.js
+++ b/static/src/js/app/constants.js
@@ -8,43 +8,43 @@ export const FORMS_FETCH = 'forms_fetch';
 export const FORMS_FETCH_PARTIAL = 'forms_fetchPartial';
 
 // lemmatization.Lemma
-export const LEMMA_FETCH = 'lemma_fetch';
 export const LEMMA_CREATE = 'lemma_create';
+export const LEMMA_FETCH = 'lemma_fetch';
 
 // lemmatized_text.LemmatizedText
 export const LEMMATIZED_TEXT_FETCH = 'lemmatizedText_fetch';
-export const LEMMATIZED_TEXT_SET_ID = 'lemmatizedText_setId';
 export const LEMMATIZED_TEXT_FETCH_TOKENS = 'lemmatizedText_fetchTokens';
-export const LEMMATIZED_TEXT_UPDATE_TOKEN = 'lemmatizedText_updateToken';
 export const LEMMATIZED_TEXT_SELECT_TOKEN = 'lemmatizedText_selectToken';
+export const LEMMATIZED_TEXT_SET_ID = 'lemmatizedText_setId';
+export const LEMMATIZED_TEXT_SHOW_KNOWN = 'lemmatizedText_showKnown';
+export const LEMMATIZED_TEXT_UPDATE_TOKEN = 'lemmatizedText_updateToken';
 
 // lemmatized_text.LemmatizedTextBookmark
-export const BOOKMARK_LIST = 'bookmark_list';
 export const BOOKMARK_CREATE = 'bookmark_create';
 export const BOOKMARK_DELETE = 'bookmark_delete';
+export const BOOKMARK_LIST = 'bookmark_list';
 
 // vocab_list.PersonalVocabularyList
 export const PERSONAL_VOCAB_LIST_FETCH = 'personalVocabularyList_fetch';
 export const PERSONAL_VOCAB_LIST_FETCH_LANG_LIST = 'personalVocabularyList_fetchLangList';
 
 // vocab_list.PersonalVocabularyListEntry
-export const PERSONAL_VOCAB_ENTRY_UPDATE = 'personalVocabularyListEntry_update';
 export const PERSONAL_VOCAB_ENTRY_CREATE = 'personalVocabularyListEntry_create';
 export const PERSONAL_VOCAB_ENTRY_DELETE = 'personalVocabularyListEntry_delete';
+export const PERSONAL_VOCAB_ENTRY_UPDATE = 'personalVocabularyListEntry_update';
 
 // vocab_list.VocabularyList
 export const VOCAB_LIST_FETCH = 'vocabularyList_fetch';
 export const VOCAB_LIST_LIST = 'vocabularyList_list';
+export const VOCAB_LIST_SET = 'vocabularyList_set';
 export const VOCAB_LIST_SET_TYPE = 'vocabularyList_setType';
 export const VOCAB_LIST_UPDATE = 'vocabularyList_update';
-export const VOCAB_LIST_SET = 'vocabularyList_set';
-export const LEMMATIZED_TEXT_SHOW_KNOWN = 'lemmatizedText_showKnown';
 
 // vocab_list.VocabularyListEntry
-export const VOCAB_ENTRY_DELETE = 'vocabularyListEntry_delete';
-export const VOCAB_ENTRY_UPDATE_MANY = 'vocabularyListEntry_updateMany';
-export const VOCAB_ENTRY_UPDATE = 'vocabularyListEntry_update';
 export const VOCAB_ENTRY_CREATE = 'vocabularyListEntry_delete';
+export const VOCAB_ENTRY_DELETE = 'vocabularyListEntry_delete';
+export const VOCAB_ENTRY_UPDATE = 'vocabularyListEntry_update';
+export const VOCAB_ENTRY_UPDATE_MANY = 'vocabularyListEntry_updateMany';
 
 // Not accessing a model
 export const SUPPORTED_LANG_LIST_FETCH = 'supportedLangList_fetch';

--- a/static/src/js/app/constants.js
+++ b/static/src/js/app/constants.js
@@ -1,45 +1,61 @@
+// hedera.Profile
 export const FETCH_ME = 'fetchMe';
-export const FETCH_VOCAB_LIST = 'fetchVocabList';
-export const DELETE_VOCAB_ENTRY = 'vocabEntryDelete';
-export const FETCH_VOCAB_LISTS = 'fetchVocabLists';
-export const FETCH_PERSONAL_VOCAB_LIST = 'fetchPersonalVocabList';
-export const SET_VOCAB_LIST_TYPE = 'setVocabListType';
-export const UPDATE_VOCAB_LIST = 'updateVocabList';
-export const UPDATE_VOCAB_LIST_ENTRIES = 'updateVocabListEntries';
-export const FETCH_TOKENS = 'fetchTokens';
-export const SELECT_TOKEN = 'selectToken';
-export const FETCH_NODE = 'fetchNode';
-export const FETCH_LEMMA = 'fetchLemma';
-export const FETCH_LEMMAS_BY_FORM = 'fetchLemmasByForm';
-export const FETCH_LEMMAS_BY_PARTIAL_FORM = 'fetchLemmasByPartialForm';
-export const UPDATE_TOKEN = 'updateToken';
-export const SET_TEXT_ID = 'setTextId';
-export const ADD_LEMMA = 'addLemma';
-export const SET_VOCAB_LIST = 'setVocabList';
-export const TOGGLE_SHOW_IN_VOCAB_LIST = 'toggleShowInVocabList';
-export const FETCH_TEXT = 'fetchText';
-export const OLD_CREATE_VOCAB_ENTRY = 'oldCreateVocabEntry';
-export const UPDATE_VOCAB_ENTRY = 'updateVocabEntry';
-export const UPDATE_PERSONAL_VOCAB_ENTRY = 'updatePersonalVocabEntry';
-export const FETCH_PERSONAL_VOCAB_LANG_LIST = 'fetchPersonalVocabLangList';
-export const CREATE_PERSONAL_VOCAB_ENTRY = 'createPersonalVocabEntry';
-export const CREATE_VOCAB_ENTRY = 'createVocabEntry';
-export const FETCH_LATTICE_NODES_BY_HEADWORD = 'fetchLatticeNodesByHeadword';
-export const FETCH_SUPPORTED_LANG_LIST = 'fetchSupportedLangList';
 // TODO add language preference
 export const SET_LANGUAGE_PREF = 'setLanguagePref';
-export const DELETE_PERSONAL_VOCAB_ENTRY = 'deletePersonalVocabEntry';
+
+// lemmatization.Form
+export const FETCH_LEMMAS_BY_FORM = 'fetchLemmasByForm';
+export const FETCH_LEMMAS_BY_PARTIAL_FORM = 'fetchLemmasByPartialForm';
+
+// lemmatization.Lemma
+export const FETCH_LEMMA = 'fetchLemma';
+export const ADD_LEMMA = 'addLemma';
+
+// lemmatized_text.LemmatizedText
+export const FETCH_TEXT = 'fetchText';
+export const SET_TEXT_ID = 'setTextId';
+export const FETCH_TOKENS = 'fetchTokens';
+export const UPDATE_TOKEN = 'updateToken';
+export const SELECT_TOKEN = 'selectToken';
+
+// lemmatized_text.LemmatizedTextBookmark
 export const FETCH_BOOKMARKS = 'fetchBookmarks';
 export const ADD_BOOKMARK = 'addBookmark';
 export const REMOVE_BOOKMARK = 'removeBookmark';
 
+// vocab_list.PersonalVocabularyList
+export const FETCH_PERSONAL_VOCAB_LIST = 'fetchPersonalVocabList';
+export const FETCH_PERSONAL_VOCAB_LANG_LIST = 'fetchPersonalVocabLangList';
+
+// vocab_list.PersonalVocabularyListEntry
+export const UPDATE_PERSONAL_VOCAB_ENTRY = 'updatePersonalVocabEntry';
+export const CREATE_PERSONAL_VOCAB_ENTRY = 'createPersonalVocabEntry';
+export const DELETE_PERSONAL_VOCAB_ENTRY = 'deletePersonalVocabEntry';
+
+// vocab_list.VocabularyList
+export const FETCH_VOCAB_LIST = 'fetchVocabList';
+export const FETCH_VOCAB_LISTS = 'fetchVocabLists';
+export const SET_VOCAB_LIST_TYPE = 'setVocabListType';
+export const UPDATE_VOCAB_LIST = 'updateVocabList';
+export const SET_VOCAB_LIST = 'setVocabList';
+export const TOGGLE_SHOW_IN_VOCAB_LIST = 'toggleShowInVocabList';
+
+// vocab_list.VocabularyListEntry
+export const DELETE_VOCAB_ENTRY = 'vocabEntryDelete';
+export const UPDATE_VOCAB_LIST_ENTRIES = 'updateVocabListEntries';
+export const UPDATE_VOCAB_ENTRY = 'updateVocabEntry';
+export const CREATE_VOCAB_ENTRY = 'createVocabEntry';
+
+// Not accessing a model
+export const FETCH_SUPPORTED_LANG_LIST = 'fetchSupportedLangList';
+
+// Just constants, not used as function names
 export const RESOLVED_NA = 'na';
 export const RESOLVED_NO_LEMMA = 'no-lemma';
 export const RESOLVED_UNRESOLVED = 'unresolved';
 export const RESOLVED_NO_AMBIGUITY = 'no-ambiguity';
 export const RESOLVED_AUTOMATIC = 'resolved-automatical';
 export const RESOLVED_MANUAL = 'resolved-manual';
-
 export const RATINGS = {
   1: 'I don\'t recognise this word',
   2: 'I recognise this word but don\'t know what it means',
@@ -47,3 +63,8 @@ export const RATINGS = {
   4: 'I definitely know what this word means but could forget soon',
   5: 'I know this word so well, I am unlikely to ever forget it',
 };
+
+// TODO: Delete these things, ensuring that they are not used.
+export const FETCH_LATTICE_NODES_BY_HEADWORD = 'fetchLatticeNodesByHeadword';
+export const FETCH_NODE = 'fetchNode';
+export const OLD_CREATE_VOCAB_ENTRY = 'oldCreateVocabEntry';

--- a/static/src/js/app/constants.js
+++ b/static/src/js/app/constants.js
@@ -1,53 +1,53 @@
 // hedera.Profile
-export const FETCH_ME = 'fetchMe';
+export const PROFILE_FETCH = 'profile_fetch';
 // TODO add language preference
-export const SET_LANGUAGE_PREF = 'setLanguagePref';
+export const PROFILE_SET_LANGUAGE_PREF = 'profile_setLanguagePref';
 
 // lemmatization.Form
-export const FETCH_LEMMAS_BY_FORM = 'fetchLemmasByForm';
-export const FETCH_LEMMAS_BY_PARTIAL_FORM = 'fetchLemmasByPartialForm';
+export const FORMS_FETCH = 'forms_fetch';
+export const FORMS_FETCH_PARTIAL = 'forms_fetchPartial';
 
 // lemmatization.Lemma
-export const FETCH_LEMMA = 'fetchLemma';
-export const ADD_LEMMA = 'addLemma';
+export const LEMMA_FETCH = 'lemma_fetch';
+export const LEMMA_CREATE = 'lemma_create';
 
 // lemmatized_text.LemmatizedText
-export const FETCH_TEXT = 'fetchText';
-export const SET_TEXT_ID = 'setTextId';
-export const FETCH_TOKENS = 'fetchTokens';
-export const UPDATE_TOKEN = 'updateToken';
-export const SELECT_TOKEN = 'selectToken';
+export const LEMMATIZED_TEXT_FETCH = 'lemmatizedText_fetch';
+export const LEMMATIZED_TEXT_SET_ID = 'lemmatizedText_setId';
+export const LEMMATIZED_TEXT_FETCH_TOKENS = 'lemmatizedText_fetchTokens';
+export const LEMMATIZED_TEXT_UPDATE_TOKEN = 'lemmatizedText_updateToken';
+export const LEMMATIZED_TEXT_SELECT_TOKEN = 'lemmatizedText_selectToken';
 
 // lemmatized_text.LemmatizedTextBookmark
-export const FETCH_BOOKMARKS = 'fetchBookmarks';
-export const ADD_BOOKMARK = 'addBookmark';
-export const REMOVE_BOOKMARK = 'removeBookmark';
+export const BOOKMARK_LIST = 'bookmark_list';
+export const BOOKMARK_CREATE = 'bookmark_create';
+export const BOOKMARK_DELETE = 'bookmark_delete';
 
 // vocab_list.PersonalVocabularyList
-export const FETCH_PERSONAL_VOCAB_LIST = 'fetchPersonalVocabList';
-export const FETCH_PERSONAL_VOCAB_LANG_LIST = 'fetchPersonalVocabLangList';
+export const PERSONAL_VOCAB_LIST_FETCH = 'personalVocabularyList_fetch';
+export const PERSONAL_VOCAB_LIST_FETCH_LANG_LIST = 'personalVocabularyList_fetchLangList';
 
 // vocab_list.PersonalVocabularyListEntry
-export const UPDATE_PERSONAL_VOCAB_ENTRY = 'updatePersonalVocabEntry';
-export const CREATE_PERSONAL_VOCAB_ENTRY = 'createPersonalVocabEntry';
-export const DELETE_PERSONAL_VOCAB_ENTRY = 'deletePersonalVocabEntry';
+export const PERSONAL_VOCAB_ENTRY_UPDATE = 'personalVocabularyListEntry_update';
+export const PERSONAL_VOCAB_ENTRY_CREATE = 'personalVocabularyListEntry_create';
+export const PERSONAL_VOCAB_ENTRY_DELETE = 'personalVocabularyListEntry_delete';
 
 // vocab_list.VocabularyList
-export const FETCH_VOCAB_LIST = 'fetchVocabList';
-export const FETCH_VOCAB_LISTS = 'fetchVocabLists';
-export const SET_VOCAB_LIST_TYPE = 'setVocabListType';
-export const UPDATE_VOCAB_LIST = 'updateVocabList';
-export const SET_VOCAB_LIST = 'setVocabList';
-export const TOGGLE_SHOW_IN_VOCAB_LIST = 'toggleShowInVocabList';
+export const VOCAB_LIST_FETCH = 'vocabularyList_fetch';
+export const VOCAB_LIST_LIST = 'vocabularyList_list';
+export const VOCAB_LIST_SET_TYPE = 'vocabularyList_setType';
+export const VOCAB_LIST_UPDATE = 'vocabularyList_update';
+export const VOCAB_LIST_SET = 'vocabularyList_set';
+export const LEMMATIZED_TEXT_SHOW_KNOWN = 'lemmatizedText_showKnown';
 
 // vocab_list.VocabularyListEntry
-export const DELETE_VOCAB_ENTRY = 'vocabEntryDelete';
-export const UPDATE_VOCAB_LIST_ENTRIES = 'updateVocabListEntries';
-export const UPDATE_VOCAB_ENTRY = 'updateVocabEntry';
-export const CREATE_VOCAB_ENTRY = 'createVocabEntry';
+export const VOCAB_ENTRY_DELETE = 'vocabularyListEntry_delete';
+export const VOCAB_ENTRY_UPDATE_MANY = 'vocabularyListEntry_updateMany';
+export const VOCAB_ENTRY_UPDATE = 'vocabularyListEntry_update';
+export const VOCAB_ENTRY_CREATE = 'vocabularyListEntry_delete';
 
 // Not accessing a model
-export const FETCH_SUPPORTED_LANG_LIST = 'fetchSupportedLangList';
+export const SUPPORTED_LANG_LIST_FETCH = 'supportedLangList_fetch';
 
 // Just constants, not used as function names
 export const RESOLVED_NA = 'na';

--- a/static/src/js/app/modules/BookmarkList.vue
+++ b/static/src/js/app/modules/BookmarkList.vue
@@ -12,12 +12,12 @@
 
 <script>
   import BookmarkItem from './BookmarkItem.vue';
-  import { FETCH_BOOKMARKS } from '../constants';
+  import { BOOKMARK_LIST } from '../constants';
 
   export default {
     components: { BookmarkItem },
     created() {
-      this.$store.dispatch(FETCH_BOOKMARKS);
+      this.$store.dispatch(BOOKMARK_LIST);
     },
     computed: {
       bookmarks() {

--- a/static/src/js/app/modules/BookmarkTextButton.vue
+++ b/static/src/js/app/modules/BookmarkTextButton.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-  import { ADD_BOOKMARK, REMOVE_BOOKMARK } from '../constants';
+  import { BOOKMARK_CREATE, BOOKMARK_DELETE } from '../constants';
 
   export default {
     props: ['textId'],
@@ -18,10 +18,10 @@
         }
       },
       addBookmark(textId) {
-        this.$store.dispatch(ADD_BOOKMARK, { textId });
+        this.$store.dispatch(BOOKMARK_CREATE, { textId });
       },
       removeBookmark(bookmarkId) {
-        this.$store.dispatch(REMOVE_BOOKMARK, { bookmarkId });
+        this.$store.dispatch(BOOKMARK_DELETE, { bookmarkId });
       },
     },
     computed: {

--- a/static/src/js/app/modules/FormDisambiguation.vue
+++ b/static/src/js/app/modules/FormDisambiguation.vue
@@ -14,7 +14,7 @@
 </template>
 <script>
   import Lemma from './Lemma.vue';
-  import { UPDATE_TOKEN, RESOLVED_MANUAL } from '../constants';
+  import { LEMMATIZED_TEXT_UPDATE_TOKEN, RESOLVED_MANUAL } from '../constants';
 
   const getGlossIds = (lemmas, lemma) => {
     const matchingLemmas = lemmas.filter((x) => x.pk === lemma.pk);
@@ -54,7 +54,7 @@
         this.updateToken(lemma, glossIds);
       },
       updateToken(lemma, glossIds = []) {
-        this.$store.dispatch(UPDATE_TOKEN, {
+        this.$store.dispatch(LEMMATIZED_TEXT_UPDATE_TOKEN, {
           id: this.$store.state.textId,
           tokenIndex: this.selectedToken.tokenIndex,
           lemmaId: lemma.pk,

--- a/static/src/js/app/modules/LatticeTree.vue
+++ b/static/src/js/app/modules/LatticeTree.vue
@@ -17,7 +17,7 @@
   import TokenHistory from './TokenHistory.vue';
 
   import api from '../api';
-  import { UPDATE_TOKEN, ADD_LEMMA, RESOLVED_MANUAL } from '../constants';
+  import { LEMMATIZED_TEXT_UPDATE_TOKEN, LEMMA_CREATE, RESOLVED_MANUAL } from '../constants';
 
   export default {
     components: {
@@ -57,7 +57,7 @@
     },
     methods: {
       onAddLemma({ lemma }) {
-        this.$store.dispatch(ADD_LEMMA, {
+        this.$store.dispatch(LEMMA_CREATE, {
           id: this.textId,
           tokenIndex: this.selectedToken.tokenIndex,
           lemma,
@@ -65,7 +65,7 @@
         });
       },
       onSelect(node) {
-        this.$store.dispatch(UPDATE_TOKEN, {
+        this.$store.dispatch(LEMMATIZED_TEXT_UPDATE_TOKEN, {
           id: this.textId,
           tokenIndex: this.selectedToken.tokenIndex,
           nodeId: node.pk,

--- a/static/src/js/app/modules/LemmatizedText.vue
+++ b/static/src/js/app/modules/LemmatizedText.vue
@@ -14,7 +14,7 @@
 </template>
 <script>
   import debounce from 'lodash.debounce';
-  import { SELECT_TOKEN, FETCH_LEMMAS_BY_FORM, FETCH_LEMMA } from '../constants';
+  import { LEMMATIZED_TEXT_SELECT_TOKEN, FORMS_FETCH, LEMMA_FETCH } from '../constants';
 
   import Token from './Token.vue';
 
@@ -72,12 +72,12 @@
 
         const fetchLemma = () => {
           if (this.selectedToken.lemma_id !== null) {
-            this.$store.dispatch(FETCH_LEMMA, { id: this.selectedToken.lemma_id });
+            this.$store.dispatch(LEMMA_FETCH, { id: this.selectedToken.lemma_id });
           }
         };
 
         const fetchLemmasByForm = () => {
-          this.$store.dispatch(FETCH_LEMMAS_BY_FORM, {
+          this.$store.dispatch(FORMS_FETCH, {
             lang: this.$store.state.text.lang,
             form: this.selectedToken.word_normalized,
           });
@@ -90,12 +90,12 @@
 
         // The debounce is delaying the call but it's accumulating all the instances
         // so the network call is happening multiple times.
-        this.$store.dispatch(SELECT_TOKEN, { token })
+        this.$store.dispatch(LEMMATIZED_TEXT_SELECT_TOKEN, { token })
           .then(debouncedFetch());
       },
       onToggleSelect(token) {
         if (this.selectedToken === token) {
-          this.$store.dispatch(SELECT_TOKEN, { token: null });
+          this.$store.dispatch(LEMMATIZED_TEXT_SELECT_TOKEN, { token: null });
         } else {
           this.selectToken(token.tokenIndex);
         }

--- a/static/src/js/app/modules/MarkResolved.vue
+++ b/static/src/js/app/modules/MarkResolved.vue
@@ -14,7 +14,7 @@
     RESOLVED_UNRESOLVED,
     RESOLVED_MANUAL,
     RESOLVED_AUTOMATIC,
-    UPDATE_TOKEN,
+    LEMMATIZED_TEXT_UPDATE_TOKEN,
   } from '../constants';
 
   export default {
@@ -62,7 +62,7 @@
         return resolved;
       },
       updateToken(token) {
-        this.$store.dispatch(UPDATE_TOKEN, {
+        this.$store.dispatch(LEMMATIZED_TEXT_UPDATE_TOKEN, {
           id: this.$store.state.textId,
           tokenIndex: token.tokenIndex,
           nodeId: this.selectedToken.node,

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -1,36 +1,36 @@
 /* eslint-disable object-curly-newline */
 import {
-  LEMMATIZED_TEXT_FETCH,
-  LEMMATIZED_TEXT_FETCH_TOKENS,
-  LEMMATIZED_TEXT_SELECT_TOKEN,
-  FETCH_NODE,
-  LEMMA_FETCH,
-  FORMS_FETCH,
-  FORMS_FETCH_PARTIAL,
-  LEMMATIZED_TEXT_UPDATE_TOKEN,
-  LEMMATIZED_TEXT_SET_ID,
-  VOCAB_LIST_LIST,
-  VOCAB_LIST_SET,
-  LEMMATIZED_TEXT_SHOW_KNOWN,
-  PERSONAL_VOCAB_LIST_FETCH,
-  OLD_CREATE_VOCAB_ENTRY,
-  VOCAB_ENTRY_UPDATE,
-  PERSONAL_VOCAB_ENTRY_UPDATE,
-  PROFILE_FETCH,
-  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
-  PERSONAL_VOCAB_ENTRY_CREATE,
-  PROFILE_SET_LANGUAGE_PREF,
-  PERSONAL_VOCAB_ENTRY_DELETE,
-  VOCAB_ENTRY_DELETE,
-  BOOKMARK_LIST,
   BOOKMARK_CREATE,
   BOOKMARK_DELETE,
+  BOOKMARK_LIST,
+  FETCH_NODE,
+  FORMS_FETCH_PARTIAL,
+  FORMS_FETCH,
+  LEMMA_FETCH,
+  LEMMATIZED_TEXT_FETCH_TOKENS,
+  LEMMATIZED_TEXT_FETCH,
+  LEMMATIZED_TEXT_SELECT_TOKEN,
+  LEMMATIZED_TEXT_SET_ID,
+  LEMMATIZED_TEXT_SHOW_KNOWN,
+  LEMMATIZED_TEXT_UPDATE_TOKEN,
+  OLD_CREATE_VOCAB_ENTRY,
+  PERSONAL_VOCAB_ENTRY_CREATE,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  PERSONAL_VOCAB_ENTRY_UPDATE,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PERSONAL_VOCAB_LIST_FETCH,
+  PROFILE_FETCH,
+  PROFILE_SET_LANGUAGE_PREF,
   SUPPORTED_LANG_LIST_FETCH,
-  VOCAB_LIST_FETCH,
-  VOCAB_LIST_SET_TYPE,
   VOCAB_ENTRY_CREATE,
-  VOCAB_LIST_UPDATE,
+  VOCAB_ENTRY_DELETE,
   VOCAB_ENTRY_UPDATE_MANY,
+  VOCAB_ENTRY_UPDATE,
+  VOCAB_LIST_FETCH,
+  VOCAB_LIST_LIST,
+  VOCAB_LIST_SET_TYPE,
+  VOCAB_LIST_SET,
+  VOCAB_LIST_UPDATE,
 } from '../constants';
 import api from '../api';
 
@@ -99,11 +99,6 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  [BOOKMARK_LIST]: ({ commit }) => (
-    api
-      .bookmark_list((data) => commit(BOOKMARK_LIST, data.data))
-      .catch(logoutOnError(commit))
-  ),
   [BOOKMARK_CREATE]: ({ dispatch, commit }, { textId }) => (
     api
       .bookmark_create(textId)
@@ -114,6 +109,11 @@ export default {
     api
       .bookmark_delete(bookmarkId)
       .then(() => dispatch(BOOKMARK_LIST))
+      .catch(logoutOnError(commit))
+  ),
+  [BOOKMARK_LIST]: ({ commit }) => (
+    api
+      .bookmark_list((data) => commit(BOOKMARK_LIST, data.data))
       .catch(logoutOnError(commit))
   ),
 
@@ -136,6 +136,17 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
+  [PERSONAL_VOCAB_ENTRY_CREATE]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
+    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_CREATE, data.data);
+    return api
+      .personalVocabularyListEntry_create(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
+      .catch(logoutOnError(commit));
+  },
+  [PERSONAL_VOCAB_ENTRY_DELETE]: ({ commit }, { id }) => {
+    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_DELETE, data.data);
+    return api.personalVocabularyListEntry_delete(id, cb)
+      .catch(logoutOnError(commit));
+  },
   // eslint-disable-next-line max-len
   [PERSONAL_VOCAB_ENTRY_UPDATE]: async ({ commit, state }, { entryId, familiarity, headword, definition, lang = null, lemmaId }) => {
     // eslint-disable-next-line max-len
@@ -159,17 +170,6 @@ export default {
     commit(VOCAB_ENTRY_UPDATE_MANY, updatedEntries);
     return null;
   },
-  [PERSONAL_VOCAB_ENTRY_CREATE]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
-    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_CREATE, data.data);
-    return api
-      .personalVocabularyListEntry_create(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
-      .catch(logoutOnError(commit));
-  },
-  [PERSONAL_VOCAB_ENTRY_DELETE]: ({ commit }, { id }) => {
-    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_DELETE, data.data);
-    return api.personalVocabularyListEntry_delete(id, cb)
-      .catch(logoutOnError(commit));
-  },
 
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
@@ -189,11 +189,11 @@ export default {
   [VOCAB_LIST_SET]: ({ commit }, { id }) => {
     commit(VOCAB_LIST_SET, id);
   },
-  [LEMMATIZED_TEXT_SHOW_KNOWN]: ({ commit }) => {
-    commit(LEMMATIZED_TEXT_SHOW_KNOWN);
-  },
   [VOCAB_LIST_SET_TYPE]: ({ commit }, { vocabListType }) => {
     commit(VOCAB_LIST_SET_TYPE, vocabListType);
+  },
+  [LEMMATIZED_TEXT_SHOW_KNOWN]: ({ commit }) => {
+    commit(LEMMATIZED_TEXT_SHOW_KNOWN);
   },
 
   /* -------------------------------------------------------------------------- */
@@ -204,6 +204,11 @@ export default {
       .vocabularyListEntry_create(vocabularyListId, headword, definition, lemmaId)
       .catch(logoutOnError(commit));
     commit(VOCAB_ENTRY_CREATE, data);
+  },
+  [VOCAB_ENTRY_DELETE]: async ({ commit }, { id }) => {
+    await api.vocabularyListEntry_delete(id)
+      .catch(logoutOnError(commit));
+    commit(VOCAB_ENTRY_DELETE, id);
   },
   [VOCAB_ENTRY_UPDATE]: async ({ commit, state }, { entryId, headword, definition, lemmaId }) => {
     let data = null;
@@ -253,11 +258,6 @@ export default {
     console.log(updatedEntries);
     commit(VOCAB_ENTRY_UPDATE_MANY, updatedEntries);
     return null;
-  },
-  [VOCAB_ENTRY_DELETE]: async ({ commit }, { id }) => {
-    await api.vocabularyListEntry_delete(id)
-      .catch(logoutOnError(commit));
-    commit(VOCAB_ENTRY_DELETE, id);
   },
 
   /* -------------------------------------------------------------------------- */

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -45,7 +45,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  [FETCH_ME]: ({ commit }) => api.hederaProfileFetch((data) => commit(FETCH_ME, data.data)),
+  [FETCH_ME]: ({ commit }) => api.fetchMe((data) => commit(FETCH_ME, data.data)),
   [SET_LANGUAGE_PREF]: ({ commit }, { lang }) => {
     const cb = commit(SET_LANGUAGE_PREF, lang);
     return api.updateMeLang(lang, cb).catch(logoutOnError(commit));

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -1,36 +1,36 @@
 /* eslint-disable object-curly-newline */
 import {
-  FETCH_TEXT,
-  FETCH_TOKENS,
-  SELECT_TOKEN,
+  LEMMATIZED_TEXT_FETCH,
+  LEMMATIZED_TEXT_FETCH_TOKENS,
+  LEMMATIZED_TEXT_SELECT_TOKEN,
   FETCH_NODE,
-  FETCH_LEMMA,
-  FETCH_LEMMAS_BY_FORM,
-  FETCH_LEMMAS_BY_PARTIAL_FORM,
-  UPDATE_TOKEN,
-  SET_TEXT_ID,
-  FETCH_VOCAB_LISTS,
-  SET_VOCAB_LIST,
-  TOGGLE_SHOW_IN_VOCAB_LIST,
-  FETCH_PERSONAL_VOCAB_LIST,
+  LEMMA_FETCH,
+  FORMS_FETCH,
+  FORMS_FETCH_PARTIAL,
+  LEMMATIZED_TEXT_UPDATE_TOKEN,
+  LEMMATIZED_TEXT_SET_ID,
+  VOCAB_LIST_LIST,
+  VOCAB_LIST_SET,
+  LEMMATIZED_TEXT_SHOW_KNOWN,
+  PERSONAL_VOCAB_LIST_FETCH,
   OLD_CREATE_VOCAB_ENTRY,
-  UPDATE_VOCAB_ENTRY,
-  UPDATE_PERSONAL_VOCAB_ENTRY,
-  FETCH_ME,
-  FETCH_PERSONAL_VOCAB_LANG_LIST,
-  CREATE_PERSONAL_VOCAB_ENTRY,
-  SET_LANGUAGE_PREF,
-  DELETE_PERSONAL_VOCAB_ENTRY,
-  DELETE_VOCAB_ENTRY,
-  FETCH_BOOKMARKS,
-  ADD_BOOKMARK,
-  REMOVE_BOOKMARK,
-  FETCH_SUPPORTED_LANG_LIST,
-  FETCH_VOCAB_LIST,
-  SET_VOCAB_LIST_TYPE,
-  CREATE_VOCAB_ENTRY,
-  UPDATE_VOCAB_LIST,
-  UPDATE_VOCAB_LIST_ENTRIES,
+  VOCAB_ENTRY_UPDATE,
+  PERSONAL_VOCAB_ENTRY_UPDATE,
+  PROFILE_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PERSONAL_VOCAB_ENTRY_CREATE,
+  PROFILE_SET_LANGUAGE_PREF,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  VOCAB_ENTRY_DELETE,
+  BOOKMARK_LIST,
+  BOOKMARK_CREATE,
+  BOOKMARK_DELETE,
+  SUPPORTED_LANG_LIST_FETCH,
+  VOCAB_LIST_FETCH,
+  VOCAB_LIST_SET_TYPE,
+  VOCAB_ENTRY_CREATE,
+  VOCAB_LIST_UPDATE,
+  VOCAB_ENTRY_UPDATE_MANY,
 } from '../constants';
 import api from '../api';
 
@@ -45,91 +45,91 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  [FETCH_ME]: ({ commit }) => api.fetchMe((data) => commit(FETCH_ME, data.data)),
-  [SET_LANGUAGE_PREF]: ({ commit }, { lang }) => {
-    const cb = commit(SET_LANGUAGE_PREF, lang);
-    return api.updateMeLang(lang, cb).catch(logoutOnError(commit));
+  [PROFILE_FETCH]: ({ commit }) => api.profile_fetch((data) => commit(PROFILE_FETCH, data.data)),
+  [PROFILE_SET_LANGUAGE_PREF]: ({ commit }, { lang }) => {
+    const cb = commit(PROFILE_SET_LANGUAGE_PREF, lang);
+    return api.profile_updateLang(lang, cb).catch(logoutOnError(commit));
   },
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
   /* -------------------------------------------------------------------------- */
-  [FETCH_LEMMAS_BY_FORM]: ({ commit }, { lang, form }) => api.fetchLemmasByForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_FORM, data)),
+  [FORMS_FETCH]: ({ commit }, { lang, form }) => api.form_fetch(lang, form, (data) => commit(FORMS_FETCH, data)),
   // Note: might be slow to looks up partial matches
-  [FETCH_LEMMAS_BY_PARTIAL_FORM]: ({ commit }, { lang, form }) => api.fetchLemmasByPartialForm(lang, form, (data) => commit(FETCH_LEMMAS_BY_PARTIAL_FORM, data)),
+  [FORMS_FETCH_PARTIAL]: ({ commit }, { lang, form }) => api.form_fetchPartial(lang, form, (data) => commit(FORMS_FETCH_PARTIAL, data)),
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Lemma                            */
   /* -------------------------------------------------------------------------- */
-  [FETCH_LEMMA]: ({ commit }, { id }) => api.fetchLemma(id, (data) => commit(FETCH_LEMMA, data)),
+  [LEMMA_FETCH]: ({ commit }, { id }) => api.lemma_fetch(id, (data) => commit(LEMMA_FETCH, data)),
 
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  [FETCH_TEXT]: ({ commit }, { id }) => api
-    .fetchText(id, (data) => commit(FETCH_TEXT, data.data))
+  [LEMMATIZED_TEXT_FETCH]: ({ commit }, { id }) => api
+    .lemmatizedText_fetch(id, (data) => commit(LEMMATIZED_TEXT_FETCH, data.data))
     .catch(logoutOnError(commit)),
-  [FETCH_TOKENS]: ({ commit }, { id, vocabListId, personalVocabListId }) => {
-    commit(SET_TEXT_ID, id);
-    const cb = (data) => commit(FETCH_TOKENS, data.data);
+  [LEMMATIZED_TEXT_FETCH_TOKENS]: ({ commit }, { id, vocabListId, personalVocabListId }) => {
+    commit(LEMMATIZED_TEXT_SET_ID, id);
+    const cb = (data) => commit(LEMMATIZED_TEXT_FETCH_TOKENS, data.data);
     return api
-      .fetchTokens(id, vocabListId, personalVocabListId, cb)
+      .lemmatizedText_fetchTokens(id, vocabListId, personalVocabListId, cb)
       .catch(logoutOnError(commit));
   },
-  [SELECT_TOKEN]: ({ commit, state }, { token }) => api.fetchTokenHistory(
+  [LEMMATIZED_TEXT_SELECT_TOKEN]: ({ commit, state }, { token }) => api.lemmatizedText_fetchTokenHistory(
     state.textId,
     token.tokenIndex,
-    (data) => commit(SELECT_TOKEN, { token, data }),
+    (data) => commit(LEMMATIZED_TEXT_SELECT_TOKEN, { token, data }),
   ),
-  [UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, lemmaId, glossIds, resolved }) => {
+  [LEMMATIZED_TEXT_UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, lemmaId, glossIds, resolved }) => {
     // Fetch the most recent lemma data
     api
-      .fetchLemma(lemmaId, (data) => commit(FETCH_LEMMA, data))
+      .lemma_fetch(lemmaId, (data) => commit(LEMMA_FETCH, data))
       .catch(logoutOnError(commit));
 
     // Callback to commit the changes once the API call has completed
-    const mutate = (data) => commit(UPDATE_TOKEN, data.data);
+    const mutate = (data) => commit(LEMMATIZED_TEXT_UPDATE_TOKEN, data.data);
 
     // Perform the API request to update the token data
     return api
-      .updateToken(id, tokenIndex, resolved, state.selectedVocabList, lemmaId, glossIds, null, mutate)
+      .lemmatizedText_updateToken(id, tokenIndex, resolved, state.selectedVocabList, lemmaId, glossIds, null, mutate)
       .catch(logoutOnError(commit));
   },
 
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  [FETCH_BOOKMARKS]: ({ commit }) => (
+  [BOOKMARK_LIST]: ({ commit }) => (
     api
-      .fetchBookmarks((data) => commit(FETCH_BOOKMARKS, data.data))
+      .bookmark_list((data) => commit(BOOKMARK_LIST, data.data))
       .catch(logoutOnError(commit))
   ),
-  [ADD_BOOKMARK]: ({ dispatch, commit }, { textId }) => (
+  [BOOKMARK_CREATE]: ({ dispatch, commit }, { textId }) => (
     api
-      .addBookmark(textId)
-      .then(() => dispatch(FETCH_BOOKMARKS))
+      .bookmark_create(textId)
+      .then(() => dispatch(BOOKMARK_LIST))
       .catch(logoutOnError(commit))
   ),
-  [REMOVE_BOOKMARK]: ({ dispatch, commit }, { bookmarkId }) => (
+  [BOOKMARK_DELETE]: ({ dispatch, commit }, { bookmarkId }) => (
     api
-      .removeBookmark(bookmarkId)
-      .then(() => dispatch(FETCH_BOOKMARKS))
+      .bookmark_delete(bookmarkId)
+      .then(() => dispatch(BOOKMARK_LIST))
       .catch(logoutOnError(commit))
   ),
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
-  [FETCH_PERSONAL_VOCAB_LIST]: async ({ commit }, { lang }) => {
+  [PERSONAL_VOCAB_LIST_FETCH]: async ({ commit }, { lang }) => {
     const { data } = await api
-      .fetchPersonalVocabList(lang)
+      .personalVocabularyList_fetch(lang)
       .catch(logoutOnError(commit));
-    commit(UPDATE_VOCAB_LIST, data.data.personalVocabList);
+    commit(VOCAB_LIST_UPDATE, data.data.personalVocabList);
   },
-  [FETCH_PERSONAL_VOCAB_LANG_LIST]: ({ commit }) => {
-    const cb = (data) => commit(FETCH_PERSONAL_VOCAB_LANG_LIST, data.data);
+  [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: ({ commit }) => {
+    const cb = (data) => commit(PERSONAL_VOCAB_LIST_FETCH_LANG_LIST, data.data);
     return api
-      .fetchPersonalVocabLangList(cb)
+      .personalVocabularyList_fetchLangList(cb)
       .catch(logoutOnError(commit));
   },
 
@@ -137,9 +137,9 @@ export default {
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
   // eslint-disable-next-line max-len
-  [UPDATE_PERSONAL_VOCAB_ENTRY]: async ({ commit, state }, { entryId, familiarity, headword, definition, lang = null, lemmaId }) => {
+  [PERSONAL_VOCAB_ENTRY_UPDATE]: async ({ commit, state }, { entryId, familiarity, headword, definition, lang = null, lemmaId }) => {
     // eslint-disable-next-line max-len
-    const { response, data } = await api.updatePersonalVocabList(state.text.id, lemmaId, familiarity, headword, definition, entryId, lang);
+    const { response, data } = await api.personalVocabularyList_update(state.text.id, lemmaId, familiarity, headword, definition, entryId, lang);
     if (response && response.status >= 400) {
       return response;
     }
@@ -156,60 +156,60 @@ export default {
     const updatedEntries = [...state.vocabList.entries];
     updatedEntries[localEntryIndex] = foundObj;
 
-    commit(UPDATE_VOCAB_LIST_ENTRIES, updatedEntries);
+    commit(VOCAB_ENTRY_UPDATE_MANY, updatedEntries);
     return null;
   },
-  [CREATE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
-    const cb = (data) => commit(CREATE_PERSONAL_VOCAB_ENTRY, data.data);
+  [PERSONAL_VOCAB_ENTRY_CREATE]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
+    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_CREATE, data.data);
     return api
-      .createPersonalVocabEntry(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
+      .personalVocabularyListEntry_create(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
       .catch(logoutOnError(commit));
   },
-  [DELETE_PERSONAL_VOCAB_ENTRY]: ({ commit }, { id }) => {
-    const cb = (data) => commit(DELETE_PERSONAL_VOCAB_ENTRY, data.data);
-    return api.deletePersonalVocabEntry(id, cb)
+  [PERSONAL_VOCAB_ENTRY_DELETE]: ({ commit }, { id }) => {
+    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_DELETE, data.data);
+    return api.personalVocabularyListEntry_delete(id, cb)
       .catch(logoutOnError(commit));
   },
 
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
   /* -------------------------------------------------------------------------- */
-  [FETCH_VOCAB_LIST]: async ({ commit }, { vocabListId }) => {
+  [VOCAB_LIST_FETCH]: async ({ commit }, { vocabListId }) => {
     const { data } = await api
-      .fetchVocabList(vocabListId)
+      .vocabularyList_fetch(vocabListId)
       .catch(logoutOnError(commit));
-    commit(UPDATE_VOCAB_LIST, data.data);
+    commit(VOCAB_LIST_UPDATE, data.data);
   },
-  [FETCH_VOCAB_LISTS]: async ({ commit, state }) => {
+  [VOCAB_LIST_LIST]: async ({ commit, state }) => {
     const { data } = await api
-      .fetchVocabLists(state.text.lang)
+      .vocabularyList_list(state.text.lang)
       .catch(logoutOnError(commit));
-    commit(FETCH_VOCAB_LISTS, data.data);
+    commit(VOCAB_LIST_LIST, data.data);
   },
-  [SET_VOCAB_LIST]: ({ commit }, { id }) => {
-    commit(SET_VOCAB_LIST, id);
+  [VOCAB_LIST_SET]: ({ commit }, { id }) => {
+    commit(VOCAB_LIST_SET, id);
   },
-  [TOGGLE_SHOW_IN_VOCAB_LIST]: ({ commit }) => {
-    commit(TOGGLE_SHOW_IN_VOCAB_LIST);
+  [LEMMATIZED_TEXT_SHOW_KNOWN]: ({ commit }) => {
+    commit(LEMMATIZED_TEXT_SHOW_KNOWN);
   },
-  [SET_VOCAB_LIST_TYPE]: ({ commit }, { vocabListType }) => {
-    commit(SET_VOCAB_LIST_TYPE, vocabListType);
+  [VOCAB_LIST_SET_TYPE]: ({ commit }, { vocabListType }) => {
+    commit(VOCAB_LIST_SET_TYPE, vocabListType);
   },
 
   /* -------------------------------------------------------------------------- */
   /*                       vocab_list.VocabularyListEntry                       */
   /* -------------------------------------------------------------------------- */
-  [CREATE_VOCAB_ENTRY]: async ({ commit }, { vocabularyListId, headword, definition, lemmaId }) => {
+  [VOCAB_ENTRY_CREATE]: async ({ commit }, { vocabularyListId, headword, definition, lemmaId }) => {
     const { data } = await api
-      .createVocabEntry(vocabularyListId, headword, definition, lemmaId)
+      .vocabularyListEntry_create(vocabularyListId, headword, definition, lemmaId)
       .catch(logoutOnError(commit));
-    commit(CREATE_VOCAB_ENTRY, data);
+    commit(VOCAB_ENTRY_CREATE, data);
   },
-  [UPDATE_VOCAB_ENTRY]: async ({ commit, state }, { entryId, headword, definition, lemmaId }) => {
+  [VOCAB_ENTRY_UPDATE]: async ({ commit, state }, { entryId, headword, definition, lemmaId }) => {
     let data = null;
     // Hit the edit endpoint with new headword and/or definition, raise error if bad status returned
     if (headword || definition) {
-      const { response, data: editData } = await api.updateVocabEntry(entryId, headword, definition);
+      const { response, data: editData } = await api.vocabularyListEntry_update(entryId, headword, definition);
       if (response && response.status >= 400) {
         return response;
       }
@@ -218,7 +218,7 @@ export default {
 
     // Hit the link endpoint with new lemmaId if provided, raise error if bad status returned
     if (lemmaId) {
-      const { response, data: linkData } = await api.linkVocabEntry(entryId, lemmaId);
+      const { response, data: linkData } = await api.vocabularyListEntry_link(entryId, lemmaId);
       if (response && response.status >= 400) {
         return response;
       }
@@ -238,7 +238,7 @@ export default {
      * to preserve the order of the vocab in the UI to streamline the user experience.
      * Note: this code does not take into account new personal vocab list data
      * if the data was updated in paralell with the editing of the personal vocab entry.
-     * This code is similar to the function in UPDATE_PERSONAL_VOCAB_ENTRY, but since
+     * This code is similar to the function in PERSONAL_VOCAB_ENTRY_UPDATE, but since
      * it's hitting an endpoint that returns a single modified vocab list entry,
      * it doesn't need to look up the new entry in the results.
      */
@@ -251,20 +251,20 @@ export default {
 
     console.log('updatedEntries:');
     console.log(updatedEntries);
-    commit(UPDATE_VOCAB_LIST_ENTRIES, updatedEntries);
+    commit(VOCAB_ENTRY_UPDATE_MANY, updatedEntries);
     return null;
   },
-  [DELETE_VOCAB_ENTRY]: async ({ commit }, { id }) => {
-    await api.deleteVocabEntry(id)
+  [VOCAB_ENTRY_DELETE]: async ({ commit }, { id }) => {
+    await api.vocabularyListEntry_delete(id)
       .catch(logoutOnError(commit));
-    commit(DELETE_VOCAB_ENTRY, id);
+    commit(VOCAB_ENTRY_DELETE, id);
   },
 
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */
   /* -------------------------------------------------------------------------- */
-  [FETCH_SUPPORTED_LANG_LIST]: ({ commit }) => (
-    api.fetchSupportedLangList((data) => commit(FETCH_SUPPORTED_LANG_LIST, data.data))
+  [SUPPORTED_LANG_LIST_FETCH]: ({ commit }) => (
+    api.supportedLangList_fetch((data) => commit(SUPPORTED_LANG_LIST_FETCH, data.data))
       .catch(logoutOnError(commit))
   ),
 
@@ -273,14 +273,14 @@ export default {
   /* -------------------------------------------------------------------------- */
   [OLD_CREATE_VOCAB_ENTRY]: async ({ commit, state }, { lemmaId, familiarity, headword, definition }) => {
     // TODO: Make DRY with updateVocabEntry
-    // TODO: this function is redundant with CREATE_PERSONAL_VOCAB_ENTRY, but works a little different.
-    // Places where it is used should be adapted to use CREATE_PERSONAL_VOCAB_ENTRY and this function should be removed.
+    // TODO: this function is redundant with PERSONAL_VOCAB_ENTRY_CREATE, but works a little different.
+    // Places where it is used should be adapted to use PERSONAL_VOCAB_ENTRY_CREATE and this function should be removed.
     const { response, data } = await api
-      .updatePersonalVocabList(state.text.id, lemmaId, familiarity, headword, definition, null, null);
+      .personalVocabularyList_update(state.text.id, lemmaId, familiarity, headword, definition, null, null);
     if (response && response.status >= 400) {
       return response;
     }
-    commit(FETCH_PERSONAL_VOCAB_LIST, data);
+    commit(PERSONAL_VOCAB_LIST_FETCH, data);
     return null;
   },
   [FETCH_NODE]: ({ commit }, { id }) => api.fetchNode(id, (data) => commit(FETCH_NODE, data)),

--- a/static/src/js/app/vuex/mutations.js
+++ b/static/src/js/app/vuex/mutations.js
@@ -29,26 +29,47 @@ import {
 } from '../constants';
 
 export default {
+  /* -------------------------------------------------------------------------- */
+  /*                               hedera.Profile                               */
+  /* -------------------------------------------------------------------------- */
   [FETCH_ME]: (state, data) => {
     state.me = data;
   },
+  [SET_LANGUAGE_PREF]: (state, data) => {
+    state.me = data;
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                             lemmatization.Form                             */
+  /* -------------------------------------------------------------------------- */
+  [FETCH_LEMMAS_BY_FORM]: (state, data) => {
+    const form = data.data;
+    state.forms = {
+      ...state.forms,
+      [form.form]: form,
+    };
+  },
+  [FETCH_LEMMAS_BY_PARTIAL_FORM]: (state, data) => {
+    const forms = data.data;
+    state.partialMatchForms = [...forms];
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                             lemmatization.Lemma                            */
+  /* -------------------------------------------------------------------------- */
+  [FETCH_LEMMA]: (state, data) => {
+    const lemma = data.data;
+    state.lemmas = {
+      ...state.lemmas,
+      [lemma.pk]: lemma,
+    };
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                       lemmatized_text.LemmatizedText                       */
+  /* -------------------------------------------------------------------------- */
   [FETCH_TEXT]: (state, data) => {
     state.text = data;
-  },
-  [UPDATE_VOCAB_LIST]: (state, data) => {
-    state.vocabList = data;
-  },
-  [UPDATE_VOCAB_LIST_ENTRIES]: (state, updatedEntries) => {
-    state.vocabList.entries = updatedEntries;
-  },
-  [FETCH_VOCAB_LIST]: (state, data) => {
-    state.vocabList = data;
-  },
-  [FETCH_VOCAB_LISTS]: (state, data) => {
-    state.vocabLists = data;
-  },
-  [FETCH_PERSONAL_VOCAB_LIST]: (state, data) => {
-    state.vocabList = data;
   },
   [SET_TEXT_ID]: (state, id) => {
     state.textId = id;
@@ -60,26 +81,6 @@ export default {
     state.selectedToken = token;
     state.selectedTokenHistory = data.data.tokenHistory;
   },
-  [FETCH_NODE]: (state, data) => {
-    state.nodes = {
-      ...state.nodes,
-      [data.pk]: data,
-    };
-  },
-  [FETCH_LEMMA]: (state, data) => {
-    const lemma = data.data;
-    state.lemmas = {
-      ...state.lemmas,
-      [lemma.pk]: lemma,
-    };
-  },
-  [FETCH_LEMMAS_BY_FORM]: (state, data) => {
-    const form = data.data;
-    state.forms = {
-      ...state.forms,
-      [form.form]: form,
-    };
-  },
   [UPDATE_TOKEN]: (state, data) => {
     state.tokens = data.tokens;
     state.selectedTokenHistory = data.tokenHistory;
@@ -87,14 +88,26 @@ export default {
       state.selectedToken = state.tokens[state.selectedToken.tokenIndex];
     }
   },
-  [SET_VOCAB_LIST]: (state, id) => {
-    state.selectedVocabList = id;
+
+  /* -------------------------------------------------------------------------- */
+  /*                   lemmatized_text.LemmatizedTextBookmark                   */
+  /* -------------------------------------------------------------------------- */
+  [FETCH_BOOKMARKS]: (state, data) => {
+    state.bookmarks = data;
   },
-  [TOGGLE_SHOW_IN_VOCAB_LIST]: (state) => {
-    state.showInVocabList = !state.showInVocabList;
-  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                      vocab_list.PersonalVocabularyList                     */
+  /* -------------------------------------------------------------------------- */
   [FETCH_PERSONAL_VOCAB_LANG_LIST]: (state, data) => {
     state.personalVocabLangList = data;
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                   vocab_list.PersonalVocabularyListEntry                   */
+  /* -------------------------------------------------------------------------- */
+  [FETCH_PERSONAL_VOCAB_LIST]: (state, data) => {
+    state.vocabList = data;
   },
   [CREATE_PERSONAL_VOCAB_ENTRY]: (state, data) => {
     state.vocabAdded = data.created;
@@ -102,37 +115,67 @@ export default {
       state.vocabList.entries = [data.data, ...state.vocabList.entries];
     }
   },
+  [DELETE_PERSONAL_VOCAB_ENTRY]: (state, data) => {
+    const index = state.vocabList.entries.findIndex((vocab) => vocab.id === data.id);
+    if (index >= 0) state.vocabList.entries.splice(index, 1);
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                          vocab_list.VocabularyList                         */
+  /* -------------------------------------------------------------------------- */
+  [UPDATE_VOCAB_LIST]: (state, data) => {
+    state.vocabList = data;
+  },
+  [FETCH_VOCAB_LIST]: (state, data) => {
+    state.vocabList = data;
+  },
+  [FETCH_VOCAB_LISTS]: (state, data) => {
+    state.vocabLists = data;
+  },
+  [SET_VOCAB_LIST]: (state, id) => {
+    state.selectedVocabList = id;
+  },
+  [TOGGLE_SHOW_IN_VOCAB_LIST]: (state) => {
+    state.showInVocabList = !state.showInVocabList;
+  },
+  [SET_VOCAB_LIST_TYPE]: (state, vocabListType) => {
+    state.vocabListType = vocabListType;
+  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                       vocab_list.VocabularyListEntry                       */
+  /* -------------------------------------------------------------------------- */
+  [UPDATE_VOCAB_LIST_ENTRIES]: (state, updatedEntries) => {
+    state.vocabList.entries = updatedEntries;
+  },
   [CREATE_VOCAB_ENTRY]: (state, data) => {
     state.vocabAdded = data.id;
     if (state.vocabList.entries) {
       state.vocabList.entries = [data, ...state.vocabList.entries];
     }
   },
-  [FETCH_LATTICE_NODES_BY_HEADWORD]: (state, data) => {
-    state.latticeNodes = data;
-  },
-  [SET_LANGUAGE_PREF]: (state, data) => {
-    state.me = data;
-  },
-  [DELETE_PERSONAL_VOCAB_ENTRY]: (state, data) => {
-    const index = state.vocabList.entries.findIndex((vocab) => vocab.id === data.id);
-    if (index >= 0) state.vocabList.entries.splice(index, 1);
-  },
   [DELETE_VOCAB_ENTRY]: (state, id) => {
     const index = state.vocabList.entries.findIndex((vocab) => vocab.id === id);
     if (index >= 0) state.vocabList.entries.splice(index, 1);
   },
-  [SET_VOCAB_LIST_TYPE]: (state, vocabListType) => {
-    state.vocabListType = vocabListType;
-  },
-  [FETCH_BOOKMARKS]: (state, data) => {
-    state.bookmarks = data;
-  },
+
+  /* -------------------------------------------------------------------------- */
+  /*                            Not accessing a model                           */
+  /* -------------------------------------------------------------------------- */
   [FETCH_SUPPORTED_LANG_LIST]: (state, data) => {
     state.supportedLanguages = data;
   },
-  [FETCH_LEMMAS_BY_PARTIAL_FORM]: (state, data) => {
-    const forms = data.data;
-    state.partialMatchForms = [...forms];
+
+  /* -------------------------------------------------------------------------- */
+  /*         TODO: Delete these things, ensuring that they are not used.        */
+  /* -------------------------------------------------------------------------- */
+  [FETCH_NODE]: (state, data) => {
+    state.nodes = {
+      ...state.nodes,
+      [data.pk]: data,
+    };
+  },
+  [FETCH_LATTICE_NODES_BY_HEADWORD]: (state, data) => {
+    state.latticeNodes = data;
   },
 };

--- a/static/src/js/app/vuex/mutations.js
+++ b/static/src/js/app/vuex/mutations.js
@@ -1,31 +1,31 @@
 import {
-  LEMMATIZED_TEXT_FETCH_TOKENS,
-  LEMMATIZED_TEXT_SELECT_TOKEN,
+  BOOKMARK_LIST,
+  FETCH_LATTICE_NODES_BY_HEADWORD,
   FETCH_NODE,
-  LEMMA_FETCH,
+  FORMS_FETCH_PARTIAL,
   FORMS_FETCH,
-  LEMMATIZED_TEXT_UPDATE_TOKEN,
-  LEMMATIZED_TEXT_SET_ID,
-  VOCAB_LIST_LIST,
-  VOCAB_LIST_SET,
-  LEMMATIZED_TEXT_SHOW_KNOWN,
+  LEMMA_FETCH,
+  LEMMATIZED_TEXT_FETCH_TOKENS,
   LEMMATIZED_TEXT_FETCH,
+  LEMMATIZED_TEXT_SELECT_TOKEN,
+  LEMMATIZED_TEXT_SET_ID,
+  LEMMATIZED_TEXT_SHOW_KNOWN,
+  LEMMATIZED_TEXT_UPDATE_TOKEN,
+  PERSONAL_VOCAB_ENTRY_CREATE,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
   PERSONAL_VOCAB_LIST_FETCH,
   PROFILE_FETCH,
-  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
-  PERSONAL_VOCAB_ENTRY_CREATE,
-  FETCH_LATTICE_NODES_BY_HEADWORD,
   PROFILE_SET_LANGUAGE_PREF,
-  PERSONAL_VOCAB_ENTRY_DELETE,
-  BOOKMARK_LIST,
   SUPPORTED_LANG_LIST_FETCH,
-  FORMS_FETCH_PARTIAL,
-  VOCAB_LIST_FETCH,
-  VOCAB_ENTRY_DELETE,
-  VOCAB_LIST_SET_TYPE,
   VOCAB_ENTRY_CREATE,
-  VOCAB_LIST_UPDATE,
+  VOCAB_ENTRY_DELETE,
   VOCAB_ENTRY_UPDATE_MANY,
+  VOCAB_LIST_FETCH,
+  VOCAB_LIST_LIST,
+  VOCAB_LIST_SET_TYPE,
+  VOCAB_LIST_SET,
+  VOCAB_LIST_UPDATE,
 } from '../constants';
 
 export default {
@@ -71,15 +71,18 @@ export default {
   [LEMMATIZED_TEXT_FETCH]: (state, data) => {
     state.text = data;
   },
-  [LEMMATIZED_TEXT_SET_ID]: (state, id) => {
-    state.textId = id;
-  },
   [LEMMATIZED_TEXT_FETCH_TOKENS]: (state, data) => {
     state.tokens = data;
   },
   [LEMMATIZED_TEXT_SELECT_TOKEN]: (state, { token, data }) => {
     state.selectedToken = token;
     state.selectedTokenHistory = data.data.tokenHistory;
+  },
+  [LEMMATIZED_TEXT_SET_ID]: (state, id) => {
+    state.textId = id;
+  },
+  [LEMMATIZED_TEXT_SHOW_KNOWN]: (state) => {
+    state.showInVocabList = !state.showInVocabList;
   },
   [LEMMATIZED_TEXT_UPDATE_TOKEN]: (state, data) => {
     state.tokens = data.tokens;
@@ -99,6 +102,9 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
+  [PERSONAL_VOCAB_LIST_FETCH]: (state, data) => {
+    state.vocabList = data;
+  },
   [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: (state, data) => {
     state.personalVocabLangList = data;
   },
@@ -106,9 +112,6 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  [PERSONAL_VOCAB_LIST_FETCH]: (state, data) => {
-    state.vocabList = data;
-  },
   [PERSONAL_VOCAB_ENTRY_CREATE]: (state, data) => {
     state.vocabAdded = data.created;
     if (state.vocabList.entries) {
@@ -123,9 +126,6 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
   /* -------------------------------------------------------------------------- */
-  [VOCAB_LIST_UPDATE]: (state, data) => {
-    state.vocabList = data;
-  },
   [VOCAB_LIST_FETCH]: (state, data) => {
     state.vocabList = data;
   },
@@ -135,19 +135,16 @@ export default {
   [VOCAB_LIST_SET]: (state, id) => {
     state.selectedVocabList = id;
   },
-  [LEMMATIZED_TEXT_SHOW_KNOWN]: (state) => {
-    state.showInVocabList = !state.showInVocabList;
-  },
   [VOCAB_LIST_SET_TYPE]: (state, vocabListType) => {
     state.vocabListType = vocabListType;
+  },
+  [VOCAB_LIST_UPDATE]: (state, data) => {
+    state.vocabList = data;
   },
 
   /* -------------------------------------------------------------------------- */
   /*                       vocab_list.VocabularyListEntry                       */
   /* -------------------------------------------------------------------------- */
-  [VOCAB_ENTRY_UPDATE_MANY]: (state, updatedEntries) => {
-    state.vocabList.entries = updatedEntries;
-  },
   [VOCAB_ENTRY_CREATE]: (state, data) => {
     state.vocabAdded = data.id;
     if (state.vocabList.entries) {
@@ -157,6 +154,9 @@ export default {
   [VOCAB_ENTRY_DELETE]: (state, id) => {
     const index = state.vocabList.entries.findIndex((vocab) => vocab.id === id);
     if (index >= 0) state.vocabList.entries.splice(index, 1);
+  },
+  [VOCAB_ENTRY_UPDATE_MANY]: (state, updatedEntries) => {
+    state.vocabList.entries = updatedEntries;
   },
 
   /* -------------------------------------------------------------------------- */

--- a/static/src/js/app/vuex/mutations.js
+++ b/static/src/js/app/vuex/mutations.js
@@ -1,55 +1,55 @@
 import {
-  FETCH_TOKENS,
-  SELECT_TOKEN,
+  LEMMATIZED_TEXT_FETCH_TOKENS,
+  LEMMATIZED_TEXT_SELECT_TOKEN,
   FETCH_NODE,
-  FETCH_LEMMA,
-  FETCH_LEMMAS_BY_FORM,
-  UPDATE_TOKEN,
-  SET_TEXT_ID,
-  FETCH_VOCAB_LISTS,
-  SET_VOCAB_LIST,
-  TOGGLE_SHOW_IN_VOCAB_LIST,
-  FETCH_TEXT,
-  FETCH_PERSONAL_VOCAB_LIST,
-  FETCH_ME,
-  FETCH_PERSONAL_VOCAB_LANG_LIST,
-  CREATE_PERSONAL_VOCAB_ENTRY,
+  LEMMA_FETCH,
+  FORMS_FETCH,
+  LEMMATIZED_TEXT_UPDATE_TOKEN,
+  LEMMATIZED_TEXT_SET_ID,
+  VOCAB_LIST_LIST,
+  VOCAB_LIST_SET,
+  LEMMATIZED_TEXT_SHOW_KNOWN,
+  LEMMATIZED_TEXT_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH,
+  PROFILE_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PERSONAL_VOCAB_ENTRY_CREATE,
   FETCH_LATTICE_NODES_BY_HEADWORD,
-  SET_LANGUAGE_PREF,
-  DELETE_PERSONAL_VOCAB_ENTRY,
-  FETCH_BOOKMARKS,
-  FETCH_SUPPORTED_LANG_LIST,
-  FETCH_LEMMAS_BY_PARTIAL_FORM,
-  FETCH_VOCAB_LIST,
-  DELETE_VOCAB_ENTRY,
-  SET_VOCAB_LIST_TYPE,
-  CREATE_VOCAB_ENTRY,
-  UPDATE_VOCAB_LIST,
-  UPDATE_VOCAB_LIST_ENTRIES,
+  PROFILE_SET_LANGUAGE_PREF,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  BOOKMARK_LIST,
+  SUPPORTED_LANG_LIST_FETCH,
+  FORMS_FETCH_PARTIAL,
+  VOCAB_LIST_FETCH,
+  VOCAB_ENTRY_DELETE,
+  VOCAB_LIST_SET_TYPE,
+  VOCAB_ENTRY_CREATE,
+  VOCAB_LIST_UPDATE,
+  VOCAB_ENTRY_UPDATE_MANY,
 } from '../constants';
 
 export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  [FETCH_ME]: (state, data) => {
+  [PROFILE_FETCH]: (state, data) => {
     state.me = data;
   },
-  [SET_LANGUAGE_PREF]: (state, data) => {
+  [PROFILE_SET_LANGUAGE_PREF]: (state, data) => {
     state.me = data;
   },
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
   /* -------------------------------------------------------------------------- */
-  [FETCH_LEMMAS_BY_FORM]: (state, data) => {
+  [FORMS_FETCH]: (state, data) => {
     const form = data.data;
     state.forms = {
       ...state.forms,
       [form.form]: form,
     };
   },
-  [FETCH_LEMMAS_BY_PARTIAL_FORM]: (state, data) => {
+  [FORMS_FETCH_PARTIAL]: (state, data) => {
     const forms = data.data;
     state.partialMatchForms = [...forms];
   },
@@ -57,7 +57,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Lemma                            */
   /* -------------------------------------------------------------------------- */
-  [FETCH_LEMMA]: (state, data) => {
+  [LEMMA_FETCH]: (state, data) => {
     const lemma = data.data;
     state.lemmas = {
       ...state.lemmas,
@@ -68,20 +68,20 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  [FETCH_TEXT]: (state, data) => {
+  [LEMMATIZED_TEXT_FETCH]: (state, data) => {
     state.text = data;
   },
-  [SET_TEXT_ID]: (state, id) => {
+  [LEMMATIZED_TEXT_SET_ID]: (state, id) => {
     state.textId = id;
   },
-  [FETCH_TOKENS]: (state, data) => {
+  [LEMMATIZED_TEXT_FETCH_TOKENS]: (state, data) => {
     state.tokens = data;
   },
-  [SELECT_TOKEN]: (state, { token, data }) => {
+  [LEMMATIZED_TEXT_SELECT_TOKEN]: (state, { token, data }) => {
     state.selectedToken = token;
     state.selectedTokenHistory = data.data.tokenHistory;
   },
-  [UPDATE_TOKEN]: (state, data) => {
+  [LEMMATIZED_TEXT_UPDATE_TOKEN]: (state, data) => {
     state.tokens = data.tokens;
     state.selectedTokenHistory = data.tokenHistory;
     if (state.selectedToken) {
@@ -92,30 +92,30 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  [FETCH_BOOKMARKS]: (state, data) => {
+  [BOOKMARK_LIST]: (state, data) => {
     state.bookmarks = data;
   },
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
-  [FETCH_PERSONAL_VOCAB_LANG_LIST]: (state, data) => {
+  [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: (state, data) => {
     state.personalVocabLangList = data;
   },
 
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  [FETCH_PERSONAL_VOCAB_LIST]: (state, data) => {
+  [PERSONAL_VOCAB_LIST_FETCH]: (state, data) => {
     state.vocabList = data;
   },
-  [CREATE_PERSONAL_VOCAB_ENTRY]: (state, data) => {
+  [PERSONAL_VOCAB_ENTRY_CREATE]: (state, data) => {
     state.vocabAdded = data.created;
     if (state.vocabList.entries) {
       state.vocabList.entries = [data.data, ...state.vocabList.entries];
     }
   },
-  [DELETE_PERSONAL_VOCAB_ENTRY]: (state, data) => {
+  [PERSONAL_VOCAB_ENTRY_DELETE]: (state, data) => {
     const index = state.vocabList.entries.findIndex((vocab) => vocab.id === data.id);
     if (index >= 0) state.vocabList.entries.splice(index, 1);
   },
@@ -123,38 +123,38 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */
   /* -------------------------------------------------------------------------- */
-  [UPDATE_VOCAB_LIST]: (state, data) => {
+  [VOCAB_LIST_UPDATE]: (state, data) => {
     state.vocabList = data;
   },
-  [FETCH_VOCAB_LIST]: (state, data) => {
+  [VOCAB_LIST_FETCH]: (state, data) => {
     state.vocabList = data;
   },
-  [FETCH_VOCAB_LISTS]: (state, data) => {
+  [VOCAB_LIST_LIST]: (state, data) => {
     state.vocabLists = data;
   },
-  [SET_VOCAB_LIST]: (state, id) => {
+  [VOCAB_LIST_SET]: (state, id) => {
     state.selectedVocabList = id;
   },
-  [TOGGLE_SHOW_IN_VOCAB_LIST]: (state) => {
+  [LEMMATIZED_TEXT_SHOW_KNOWN]: (state) => {
     state.showInVocabList = !state.showInVocabList;
   },
-  [SET_VOCAB_LIST_TYPE]: (state, vocabListType) => {
+  [VOCAB_LIST_SET_TYPE]: (state, vocabListType) => {
     state.vocabListType = vocabListType;
   },
 
   /* -------------------------------------------------------------------------- */
   /*                       vocab_list.VocabularyListEntry                       */
   /* -------------------------------------------------------------------------- */
-  [UPDATE_VOCAB_LIST_ENTRIES]: (state, updatedEntries) => {
+  [VOCAB_ENTRY_UPDATE_MANY]: (state, updatedEntries) => {
     state.vocabList.entries = updatedEntries;
   },
-  [CREATE_VOCAB_ENTRY]: (state, data) => {
+  [VOCAB_ENTRY_CREATE]: (state, data) => {
     state.vocabAdded = data.id;
     if (state.vocabList.entries) {
       state.vocabList.entries = [data, ...state.vocabList.entries];
     }
   },
-  [DELETE_VOCAB_ENTRY]: (state, id) => {
+  [VOCAB_ENTRY_DELETE]: (state, id) => {
     const index = state.vocabList.entries.findIndex((vocab) => vocab.id === id);
     if (index >= 0) state.vocabList.entries.splice(index, 1);
   },
@@ -162,7 +162,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */
   /* -------------------------------------------------------------------------- */
-  [FETCH_SUPPORTED_LANG_LIST]: (state, data) => {
+  [SUPPORTED_LANG_LIST_FETCH]: (state, data) => {
     state.supportedLanguages = data;
   },
 

--- a/static/src/js/app/vuex/tests/actions.spec.js
+++ b/static/src/js/app/vuex/tests/actions.spec.js
@@ -1,3 +1,9 @@
+import {
+  PERSONAL_VOCAB_ENTRY_CREATE,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PROFILE_SET_LANGUAGE_PREF,
+} from '../../constants';
 import actions from '../actions';
 
 let url = '';
@@ -21,7 +27,7 @@ jest.mock('axios', () => ({
   defaults: { withCredentials: true },
 }));
 describe('Actions', () => {
-  describe('FETCH_PERSONAL_VOCAB_LANG_LIST', () => {
+  describe('PERSONAL_VOCAB_LIST_FETCH_LANG_LIST', () => {
     it('successfully calls fetchPersonalVocabLangList action to update state', async () => {
       const commit = jest.fn();
       // TODO: when passed in the response isnt returned from the commit in the expect block, check why
@@ -37,15 +43,15 @@ describe('Actions', () => {
       //       }
       //     ]
       //   };
-      await actions.fetchPersonalVocabLangList({ commit });
+      await actions[PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]({ commit });
       expect(url).toBe('/api/v1/personal_vocab_list/quick_add/');
     //   expect(commit).toHaveBeenCalledWith(
-    //     'fetchPersonalVocabLangList',
+    //     PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
     //     undefined
     //   );
     });
   });
-  describe('CREATE_PERSONAL_VOCAB_ENTRY', () => {
+  describe('PERSONAL_VOCAB_ENTRY_CREATE', () => {
     it('successfully calls createPersonalVocabEntry action to update state', async () => {
       const commit = jest.fn();
       const payload = {
@@ -57,8 +63,8 @@ describe('Actions', () => {
         vocabularyListId: 1,
       };
       //   const response = { data: { created: true } };
-      await actions.createPersonalVocabEntry({ commit }, payload);
-      // expect(commit).toHaveBeenCalledWith('createPersonalVocabEntry', response)
+      await actions[PERSONAL_VOCAB_ENTRY_CREATE]({ commit }, payload);
+      // expect(commit).toHaveBeenCalledWith(PERSONAL_VOCAB_ENTRY_CREATE, response)
       expect(url).toBe('/api/v1/personal_vocab_list/quick_add/');
       expect(body).toEqual({
         headword: 'ergo',
@@ -71,22 +77,22 @@ describe('Actions', () => {
     });
   });
 
-  describe('SET_LANGUAGE_PREF', () => {
-    it('successfully calls setLanguagePref', async () => {
+  describe('PROFILE_SET_LANGUAGE_PREF', () => {
+    it('successfully calls PROFILE_SET_LANGUAGE_PREF', async () => {
       const commit = jest.fn();
       const payload = {
         lang: 'lat',
       };
-      await actions.setLanguagePref({ commit }, payload);
-      expect(commit).toHaveBeenCalledWith('setLanguagePref', 'lat');
+      await actions[PROFILE_SET_LANGUAGE_PREF]({ commit }, payload);
+      expect(commit).toHaveBeenCalledWith(PROFILE_SET_LANGUAGE_PREF, 'lat');
     });
   });
-  describe('DELETE_PERSONAL_VOCAB_ENTRY', () => {
-    it('successfully calls deletePersonalVocabEntry', async () => {
+  describe('PERSONAL_VOCAB_ENTRY_DELETE', () => {
+    it('successfully calls PERSONAL_VOCAB_ENTRY_DELETE', async () => {
       const commit = jest.fn();
       const payload = { id: 1 };
-      await actions.deletePersonalVocabEntry({ commit }, payload);
-      expect(commit).toHaveBeenCalledWith('deletePersonalVocabEntry', payload);
+      await actions[PERSONAL_VOCAB_ENTRY_DELETE]({ commit }, payload);
+      expect(commit).toHaveBeenCalledWith(PERSONAL_VOCAB_ENTRY_DELETE, payload);
       expect(body.data).toEqual(payload);
     });
   });

--- a/static/src/js/app/vuex/tests/mutations.spec.js
+++ b/static/src/js/app/vuex/tests/mutations.spec.js
@@ -1,8 +1,14 @@
+import {
+  PERSONAL_VOCAB_ENTRY_CREATE,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PROFILE_SET_LANGUAGE_PREF,
+} from '../../constants';
 import mutations from '../mutations';
 import state from '../state';
 
 describe('Mutations', () => {
-  describe('fetchPersonalVocabLangList', () => {
+  describe('PERSONAL_VOCAB_LIST_FETCH_LANG_LIST', () => {
     it('successfully updates state', () => {
       const data = [
         {
@@ -15,7 +21,7 @@ describe('Mutations', () => {
         },
       ];
 
-      mutations.fetchPersonalVocabLangList(state, data);
+      mutations[PERSONAL_VOCAB_LIST_FETCH_LANG_LIST](state, data);
       expect(state.personalVocabLangList).toBe(data);
     });
   });
@@ -34,7 +40,7 @@ describe('Mutations', () => {
     };
 
     it('successfully updates the state without entries fetched', () => {
-      mutations.createPersonalVocabEntry(state, data);
+      mutations[PERSONAL_VOCAB_ENTRY_CREATE](state, data);
       expect(state.vocabAdded).toBe(true);
       expect(state.vocabList.entries).toBe(undefined);
     });
@@ -56,13 +62,13 @@ describe('Mutations', () => {
         },
       };
 
-      mutations.createPersonalVocabEntry(updatedState, data);
+      mutations[PERSONAL_VOCAB_ENTRY_CREATE](updatedState, data);
       expect(updatedState.vocabAdded).toBe(true);
       expect(updatedState.vocabList.entries.length).toBe(2);
     });
   });
 
-  describe('setLanguagePref', () => {
+  describe('PROFILE_SET_LANGUAGE_PREF', () => {
     it('successfully updates the state', () => {
       const data = {
         email: 'testing@test.com',
@@ -70,11 +76,11 @@ describe('Mutations', () => {
         showNodeIds: 'toggle',
         lang: 'lat',
       };
-      mutations.setLanguagePref(state, data);
+      mutations[PROFILE_SET_LANGUAGE_PREF](state, data);
       expect(state.me).toEqual(data);
     });
   });
-  describe('deletePersonalVocabEntry', () => {
+  describe('PERSONAL_VOCAB_ENTRY_DELETE', () => {
     it('successfully updates the state', () => {
       const modifiedState = {
         ...state,
@@ -92,7 +98,7 @@ describe('Mutations', () => {
         },
       };
       const data = { data: true, id: 1 };
-      mutations.deletePersonalVocabEntry(modifiedState, data);
+      mutations[PERSONAL_VOCAB_ENTRY_DELETE](modifiedState, data);
       expect(modifiedState.vocabList.entries.length).toBe(0);
     });
     it('unsuccessfully updates the state', () => {
@@ -112,7 +118,7 @@ describe('Mutations', () => {
         },
       };
       const data = { data: true, id: 11 };
-      mutations.deletePersonalVocabEntry(modifiedState, data);
+      mutations[PERSONAL_VOCAB_ENTRY_DELETE](modifiedState, data);
       expect(modifiedState.vocabList.entries.length).toBe(1);
     });
   });

--- a/static/src/js/tests/BookmarkTextButton.spec.js
+++ b/static/src/js/tests/BookmarkTextButton.spec.js
@@ -1,7 +1,7 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 
-import { ADD_BOOKMARK, REMOVE_BOOKMARK } from '../app/constants';
+import { BOOKMARK_CREATE, BOOKMARK_DELETE } from '../app/constants';
 import BookmarkTextButton from '../app/modules/BookmarkTextButton.vue';
 
 const localVue = createLocalVue();
@@ -57,8 +57,8 @@ describe('BookmarkTextButton', () => {
 
   beforeEach(() => {
     actions = {
-      [ADD_BOOKMARK]: jest.fn(),
-      [REMOVE_BOOKMARK]: jest.fn(),
+      [BOOKMARK_CREATE]: jest.fn(),
+      [BOOKMARK_DELETE]: jest.fn(),
     };
     store = new Vuex.Store({
       state: { bookmarks },
@@ -90,7 +90,7 @@ describe('BookmarkTextButton', () => {
     const button = wrapper.find('button');
     await button.trigger('click.prevent');
 
-    expect(actions[ADD_BOOKMARK]).toHaveBeenCalled();
+    expect(actions[BOOKMARK_CREATE]).toHaveBeenCalled();
   });
 
   it('removes the bookmark when the button is pressed and the text is not bookmarked', async () => {
@@ -99,6 +99,6 @@ describe('BookmarkTextButton', () => {
     const button = wrapper.find('button');
     await button.trigger('click.prevent');
 
-    expect(actions[REMOVE_BOOKMARK]).toHaveBeenCalled();
+    expect(actions[BOOKMARK_DELETE]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/Dashboard.spec.js
+++ b/static/src/js/tests/Dashboard.spec.js
@@ -1,6 +1,6 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
-import { FETCH_ME, FETCH_SUPPORTED_LANG_LIST } from '../app/constants';
+import { PROFILE_FETCH, SUPPORTED_LANG_LIST_FETCH } from '../app/constants';
 import Dashboard from '../app/Dashboard.vue';
 
 const localVue = createLocalVue();
@@ -11,8 +11,8 @@ describe('Dashboard', () => {
   let store;
   beforeEach(() => {
     actions = {
-      [FETCH_ME]: jest.fn(),
-      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
+      [PROFILE_FETCH]: jest.fn(),
+      [SUPPORTED_LANG_LIST_FETCH]: jest.fn(),
     };
 
     store = new Vuex.Store({

--- a/static/src/js/tests/Dashboard.spec.js
+++ b/static/src/js/tests/Dashboard.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
+import { FETCH_ME, FETCH_SUPPORTED_LANG_LIST } from '../app/constants';
 import Dashboard from '../app/Dashboard.vue';
 
 const localVue = createLocalVue();
@@ -10,7 +11,8 @@ describe('Dashboard', () => {
   let store;
   beforeEach(() => {
     actions = {
-      fetchMe: jest.fn(),
+      [FETCH_ME]: jest.fn(),
+      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
     };
 
     store = new Vuex.Store({

--- a/static/src/js/tests/QuickVocabForm.spec.js
+++ b/static/src/js/tests/QuickVocabForm.spec.js
@@ -3,13 +3,13 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 import QuickVocabAddForm from '../app/components/quick-add-button/QuickAddButton.vue';
 import {
-  CREATE_VOCAB_ENTRY,
-  FETCH_LEMMA,
-  FETCH_LEMMAS_BY_FORM,
-  FETCH_ME,
-  FETCH_PERSONAL_VOCAB_LANG_LIST,
-  FETCH_SUPPORTED_LANG_LIST,
-  SET_LANGUAGE_PREF,
+  VOCAB_ENTRY_CREATE,
+  LEMMA_FETCH,
+  FORMS_FETCH,
+  PROFILE_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  SUPPORTED_LANG_LIST_FETCH,
+  PROFILE_SET_LANGUAGE_PREF,
 } from '../app/constants';
 import testData from './testData';
 
@@ -19,13 +19,13 @@ localVue.use(Vuex);
 describe('QuickVocabForm', () => {
   let store;
   const actions = {
-    [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
-    [CREATE_VOCAB_ENTRY]: jest.fn(),
-    [FETCH_LEMMAS_BY_FORM]: jest.fn(),
-    [FETCH_ME]: jest.fn(),
-    [SET_LANGUAGE_PREF]: jest.fn(),
-    [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
-    [FETCH_LEMMA]: jest.fn(),
+    [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: jest.fn(),
+    [VOCAB_ENTRY_CREATE]: jest.fn(),
+    [FORMS_FETCH]: jest.fn(),
+    [PROFILE_FETCH]: jest.fn(),
+    [PROFILE_SET_LANGUAGE_PREF]: jest.fn(),
+    [SUPPORTED_LANG_LIST_FETCH]: jest.fn(),
+    [LEMMA_FETCH]: jest.fn(),
   };
   const state = {
     personalVocabLangList: [
@@ -89,7 +89,7 @@ describe('QuickVocabForm', () => {
   it('fails to calls store createVocabEntry "submit" when button is clicked', () => {
     const wrapper = mount(QuickVocabAddForm, { store, localVue });
     wrapper.find("[type='submit']").trigger('click');
-    expect(actions[CREATE_VOCAB_ENTRY]).toHaveBeenCalledTimes(0);
+    expect(actions[VOCAB_ENTRY_CREATE]).toHaveBeenCalledTimes(0);
   });
 
   it('successfully calls store createVocabEntry "submit" when button is clicked', async () => {
@@ -119,6 +119,6 @@ describe('QuickVocabForm', () => {
       .setValue('testGloss');
     await Vue.nextTick();
     await wrapper.find("[type='submit']").trigger('click');
-    expect(actions[CREATE_VOCAB_ENTRY]).toHaveBeenCalled();
+    expect(actions[VOCAB_ENTRY_CREATE]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/QuickVocabForm.spec.js
+++ b/static/src/js/tests/QuickVocabForm.spec.js
@@ -2,6 +2,15 @@ import { createLocalVue, mount } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import QuickVocabAddForm from '../app/components/quick-add-button/QuickAddButton.vue';
+import {
+  CREATE_VOCAB_ENTRY,
+  FETCH_LEMMA,
+  FETCH_LEMMAS_BY_FORM,
+  FETCH_ME,
+  FETCH_PERSONAL_VOCAB_LANG_LIST,
+  FETCH_SUPPORTED_LANG_LIST,
+  SET_LANGUAGE_PREF,
+} from '../app/constants';
 import testData from './testData';
 
 const localVue = createLocalVue();
@@ -10,14 +19,13 @@ localVue.use(Vuex);
 describe('QuickVocabForm', () => {
   let store;
   const actions = {
-    fetchPersonalVocabLangList: jest.fn(),
-    createPersonalVocabEntry: jest.fn(),
-    createVocabEntry: jest.fn(),
-    fetchLemmasByForm: jest.fn(),
-    fetchMe: jest.fn(),
-    setLanguagePref: jest.fn(),
-    fetchSupportedLangList: jest.fn(),
-    fetchLemma: jest.fn(),
+    [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
+    [CREATE_VOCAB_ENTRY]: jest.fn(),
+    [FETCH_LEMMAS_BY_FORM]: jest.fn(),
+    [FETCH_ME]: jest.fn(),
+    [SET_LANGUAGE_PREF]: jest.fn(),
+    [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
+    [FETCH_LEMMA]: jest.fn(),
   };
   const state = {
     personalVocabLangList: [
@@ -81,7 +89,7 @@ describe('QuickVocabForm', () => {
   it('fails to calls store createVocabEntry "submit" when button is clicked', () => {
     const wrapper = mount(QuickVocabAddForm, { store, localVue });
     wrapper.find("[type='submit']").trigger('click');
-    expect(actions.createVocabEntry).toHaveBeenCalledTimes(0);
+    expect(actions[CREATE_VOCAB_ENTRY]).toHaveBeenCalledTimes(0);
   });
 
   it('successfully calls store createVocabEntry "submit" when button is clicked', async () => {
@@ -111,6 +119,6 @@ describe('QuickVocabForm', () => {
       .setValue('testGloss');
     await Vue.nextTick();
     await wrapper.find("[type='submit']").trigger('click');
-    expect(actions.createVocabEntry).toHaveBeenCalled();
+    expect(actions[CREATE_VOCAB_ENTRY]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/VocabGeneral.spec.js
+++ b/static/src/js/tests/VocabGeneral.spec.js
@@ -1,5 +1,14 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
+import {
+  DELETE_VOCAB_ENTRY,
+  FETCH_ME,
+  FETCH_PERSONAL_VOCAB_LANG_LIST,
+  FETCH_SUPPORTED_LANG_LIST,
+  FETCH_VOCAB_LIST,
+  SET_VOCAB_LIST_TYPE,
+  UPDATE_VOCAB_ENTRY,
+} from '../app/constants';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
 
@@ -18,15 +27,13 @@ describe('VocabGeneral', () => {
   };
   beforeEach(() => {
     actions = {
-      deletePersonalVocabEntry: jest.fn(),
-      fetchMe: jest.fn(),
-      fetchPersonalVocabLangList: jest.fn(),
-      fetchPersonalVocabList: jest.fn(),
-      fetchSupportedLangList: jest.fn(),
-      fetchVocabList: jest.fn(),
-      setVocabListType: jest.fn(),
-      updateVocabEntry: jest.fn(),
-      vocabEntryDelete: jest.fn(),
+      [FETCH_ME]: jest.fn(),
+      [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
+      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
+      [FETCH_VOCAB_LIST]: jest.fn(),
+      [SET_VOCAB_LIST_TYPE]: jest.fn(),
+      [UPDATE_VOCAB_ENTRY]: jest.fn(),
+      [DELETE_VOCAB_ENTRY]: jest.fn(),
     };
 
     store = new Vuex.Store({
@@ -52,7 +59,7 @@ describe('VocabGeneral', () => {
     const wrapper = mount(PersonalVocab, { store, localVue });
     await wrapper.find('#td-edit-button').trigger('click');
     await wrapper.find('#td-save-button').trigger('click');
-    expect(actions.updateVocabEntry).toHaveBeenCalled();
+    expect(actions[UPDATE_VOCAB_ENTRY]).toHaveBeenCalled();
   });
 
   it('loads in delete button Vocab - general', async () => {
@@ -77,6 +84,6 @@ describe('VocabGeneral', () => {
     });
     await wrapper.find('#td-edit-button').trigger('click');
     wrapper.find('#td-delete-button').trigger('click');
-    expect(actions.vocabEntryDelete).toHaveBeenCalled();
+    expect(actions[DELETE_VOCAB_ENTRY]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/VocabGeneral.spec.js
+++ b/static/src/js/tests/VocabGeneral.spec.js
@@ -1,13 +1,13 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import {
-  DELETE_VOCAB_ENTRY,
-  FETCH_ME,
-  FETCH_PERSONAL_VOCAB_LANG_LIST,
-  FETCH_SUPPORTED_LANG_LIST,
-  FETCH_VOCAB_LIST,
-  SET_VOCAB_LIST_TYPE,
-  UPDATE_VOCAB_ENTRY,
+  VOCAB_ENTRY_DELETE,
+  PROFILE_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  SUPPORTED_LANG_LIST_FETCH,
+  VOCAB_LIST_FETCH,
+  VOCAB_LIST_SET_TYPE,
+  VOCAB_ENTRY_UPDATE,
 } from '../app/constants';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
@@ -27,13 +27,13 @@ describe('VocabGeneral', () => {
   };
   beforeEach(() => {
     actions = {
-      [FETCH_ME]: jest.fn(),
-      [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
-      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
-      [FETCH_VOCAB_LIST]: jest.fn(),
-      [SET_VOCAB_LIST_TYPE]: jest.fn(),
-      [UPDATE_VOCAB_ENTRY]: jest.fn(),
-      [DELETE_VOCAB_ENTRY]: jest.fn(),
+      [PROFILE_FETCH]: jest.fn(),
+      [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: jest.fn(),
+      [SUPPORTED_LANG_LIST_FETCH]: jest.fn(),
+      [VOCAB_LIST_FETCH]: jest.fn(),
+      [VOCAB_LIST_SET_TYPE]: jest.fn(),
+      [VOCAB_ENTRY_UPDATE]: jest.fn(),
+      [VOCAB_ENTRY_DELETE]: jest.fn(),
     };
 
     store = new Vuex.Store({
@@ -59,7 +59,7 @@ describe('VocabGeneral', () => {
     const wrapper = mount(PersonalVocab, { store, localVue });
     await wrapper.find('#td-edit-button').trigger('click');
     await wrapper.find('#td-save-button').trigger('click');
-    expect(actions[UPDATE_VOCAB_ENTRY]).toHaveBeenCalled();
+    expect(actions[VOCAB_ENTRY_UPDATE]).toHaveBeenCalled();
   });
 
   it('loads in delete button Vocab - general', async () => {
@@ -84,6 +84,6 @@ describe('VocabGeneral', () => {
     });
     await wrapper.find('#td-edit-button').trigger('click');
     wrapper.find('#td-delete-button').trigger('click');
-    expect(actions[DELETE_VOCAB_ENTRY]).toHaveBeenCalled();
+    expect(actions[VOCAB_ENTRY_DELETE]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/VocabPersonal.spec.js
+++ b/static/src/js/tests/VocabPersonal.spec.js
@@ -1,13 +1,13 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
 import {
-  DELETE_PERSONAL_VOCAB_ENTRY,
-  FETCH_ME,
-  FETCH_PERSONAL_VOCAB_LANG_LIST,
-  FETCH_PERSONAL_VOCAB_LIST,
-  FETCH_SUPPORTED_LANG_LIST,
-  SET_VOCAB_LIST_TYPE,
-  UPDATE_PERSONAL_VOCAB_ENTRY,
+  PERSONAL_VOCAB_ENTRY_DELETE,
+  PROFILE_FETCH,
+  PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+  PERSONAL_VOCAB_LIST_FETCH,
+  SUPPORTED_LANG_LIST_FETCH,
+  VOCAB_LIST_SET_TYPE,
+  PERSONAL_VOCAB_ENTRY_UPDATE,
 } from '../app/constants';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
@@ -28,13 +28,13 @@ describe('VocabPersonal', () => {
   };
   beforeEach(() => {
     actions = {
-      [DELETE_PERSONAL_VOCAB_ENTRY]: jest.fn(),
-      [FETCH_ME]: jest.fn(),
-      [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
-      [FETCH_PERSONAL_VOCAB_LIST]: jest.fn(),
-      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
-      [SET_VOCAB_LIST_TYPE]: jest.fn(),
-      [UPDATE_PERSONAL_VOCAB_ENTRY]: jest.fn(),
+      [PERSONAL_VOCAB_ENTRY_DELETE]: jest.fn(),
+      [PROFILE_FETCH]: jest.fn(),
+      [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: jest.fn(),
+      [PERSONAL_VOCAB_LIST_FETCH]: jest.fn(),
+      [SUPPORTED_LANG_LIST_FETCH]: jest.fn(),
+      [VOCAB_LIST_SET_TYPE]: jest.fn(),
+      [PERSONAL_VOCAB_ENTRY_UPDATE]: jest.fn(),
     };
 
     propsData = {
@@ -58,7 +58,7 @@ describe('VocabPersonal', () => {
     const wrapper = mount(PersonalVocab, { propsData, store, localVue });
     await wrapper.find('#td-edit-button').trigger('click');
     await wrapper.find('#td-save-button').trigger('click');
-    expect(actions[UPDATE_PERSONAL_VOCAB_ENTRY]).toHaveBeenCalled();
+    expect(actions[PERSONAL_VOCAB_ENTRY_UPDATE]).toHaveBeenCalled();
   });
 
   it('loads in delete button Vocab - personal', async () => {
@@ -84,6 +84,6 @@ describe('VocabPersonal', () => {
     });
     await wrapper.find('#td-edit-button').trigger('click');
     wrapper.find('#td-delete-button').trigger('click');
-    expect(actions[DELETE_PERSONAL_VOCAB_ENTRY]).toHaveBeenCalled();
+    expect(actions[PERSONAL_VOCAB_ENTRY_DELETE]).toHaveBeenCalled();
   });
 });

--- a/static/src/js/tests/VocabPersonal.spec.js
+++ b/static/src/js/tests/VocabPersonal.spec.js
@@ -1,5 +1,14 @@
 import { createLocalVue, mount } from '@vue/test-utils';
 import Vuex from 'vuex';
+import {
+  DELETE_PERSONAL_VOCAB_ENTRY,
+  FETCH_ME,
+  FETCH_PERSONAL_VOCAB_LANG_LIST,
+  FETCH_PERSONAL_VOCAB_LIST,
+  FETCH_SUPPORTED_LANG_LIST,
+  SET_VOCAB_LIST_TYPE,
+  UPDATE_PERSONAL_VOCAB_ENTRY,
+} from '../app/constants';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
 
@@ -19,15 +28,13 @@ describe('VocabPersonal', () => {
   };
   beforeEach(() => {
     actions = {
-      deletePersonalVocabEntry: jest.fn(),
-      fetchMe: jest.fn(),
-      fetchPersonalVocabLangList: jest.fn(),
-      fetchPersonalVocabList: jest.fn(),
-      fetchSupportedLangList: jest.fn(),
-      fetchVocabList: jest.fn(),
-      setVocabListType: jest.fn(),
-      updatePersonalVocabEntry: jest.fn(),
-      vocabEntryDelete: jest.fn(),
+      [DELETE_PERSONAL_VOCAB_ENTRY]: jest.fn(),
+      [FETCH_ME]: jest.fn(),
+      [FETCH_PERSONAL_VOCAB_LANG_LIST]: jest.fn(),
+      [FETCH_PERSONAL_VOCAB_LIST]: jest.fn(),
+      [FETCH_SUPPORTED_LANG_LIST]: jest.fn(),
+      [SET_VOCAB_LIST_TYPE]: jest.fn(),
+      [UPDATE_PERSONAL_VOCAB_ENTRY]: jest.fn(),
     };
 
     propsData = {
@@ -51,7 +58,7 @@ describe('VocabPersonal', () => {
     const wrapper = mount(PersonalVocab, { propsData, store, localVue });
     await wrapper.find('#td-edit-button').trigger('click');
     await wrapper.find('#td-save-button').trigger('click');
-    expect(actions.updatePersonalVocabEntry).toHaveBeenCalled();
+    expect(actions[UPDATE_PERSONAL_VOCAB_ENTRY]).toHaveBeenCalled();
   });
 
   it('loads in delete button Vocab - personal', async () => {
@@ -77,6 +84,6 @@ describe('VocabPersonal', () => {
     });
     await wrapper.find('#td-edit-button').trigger('click');
     wrapper.find('#td-delete-button').trigger('click');
-    expect(actions.deletePersonalVocabEntry).toHaveBeenCalled();
+    expect(actions[DELETE_PERSONAL_VOCAB_ENTRY]).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR is an attempt at tidying up the api and vuex functions in the Hedera front end. Naming conventions are currently inconsistent, and functions that work with the same data models are not grouped together, making it harder to keep track of what methods of interacting with the back end are available in Vue.

To that end, this PR does the following:
- Categorizes the api and vuex functions under headers based on what underlying Django models they interact with
- Implements a consistent naming structure of `dataModel_action` for api and vuex functions. Since constants are all caps with words separated by underscores, they follow a structure of `DATA_MODEL_ACTION`.
- Implements a consistent vocabulary for actions: `get`, `list`, `create`, `update`, `delete`. These actions may be modified if there is a specific part of the data model being accessed, as in `profile_updateLang`
- Ensures that constants are used consistently where applicable. Many tests do not use constants for vuex actions and mutations, which is the convention used in the code base.
- Propagates the name changes through the Vue code base to ensure that tests still pass and code style is respected.

There are a lot of changes to a lot of files, and looking at files changed will make it hard to assess what's changed. Instead, I recommend looking at the listed below. I'm finding that links to files within commits load a bit slowly, so for the second and third items give the page a few seconds to scroll to the right file.

1. [Categorizing api and vuex functions](https://github.com/Hedera-Lang-Learn/hedera/pull/470/commits/61d3e2f9a3425b6203b6c83cca4cb7f8484a82d5)
2. [Renaming api functions](https://github.com/Hedera-Lang-Learn/hedera/pull/470/commits/79f065cdca5b71511b3e91e33d189b408632c3a3#diff-752cdfd8bbe9b64ad33d5be382da400ef0b07e3ac9bf2e82a14056a26dc5c05a) in [rename commit](https://github.com/Hedera-Lang-Learn/hedera/pull/470/commits/79f065cdca5b71511b3e91e33d189b408632c3a3)
3. [Renaming constants](https://github.com/Hedera-Lang-Learn/hedera/pull/470/commits/79f065cdca5b71511b3e91e33d189b408632c3a3#diff-ce4d27a0ec3307c53650b6b400c4dd55a134ac94e7095acade373627af4ef9bc) in [rename commit](https://github.com/Hedera-Lang-Learn/hedera/pull/470/commits/79f065cdca5b71511b3e91e33d189b408632c3a3)

Those are the conceptual changes, everything else is just making sure that Hedera still works with those changes in place.