### PR TITLE
fix unknown custom element in jest test

### DIFF
--- a/static/src/js/tests/VocabGeneral.spec.js
+++ b/static/src/js/tests/VocabGeneral.spec.js
@@ -1,10 +1,12 @@
 import { createLocalVue, mount } from '@vue/test-utils';
+import { BootstrapVue } from 'bootstrap-vue';
 import Vuex from 'vuex';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+localVue.use(BootstrapVue);
 
 describe('VocabGeneral', () => {
   let actions;

--- a/static/src/js/tests/VocabGeneral.spec.js
+++ b/static/src/js/tests/VocabGeneral.spec.js
@@ -6,6 +6,7 @@ import testData from './testData';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+// BootstrapVue plugin to mitigate [Vue warn]: Unknown custom element
 localVue.use(BootstrapVue);
 
 describe('VocabGeneral', () => {

--- a/static/src/js/tests/VocabPersonal.spec.js
+++ b/static/src/js/tests/VocabPersonal.spec.js
@@ -6,6 +6,7 @@ import testData from './testData';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+// BootstrapVue plugin to mitigate [Vue warn]: Unknown custom element
 localVue.use(BootstrapVue);
 
 describe('VocabPersonal', () => {

--- a/static/src/js/tests/VocabPersonal.spec.js
+++ b/static/src/js/tests/VocabPersonal.spec.js
@@ -1,10 +1,12 @@
 import { createLocalVue, mount } from '@vue/test-utils';
+import { BootstrapVue } from 'bootstrap-vue';
 import Vuex from 'vuex';
 import PersonalVocab from '../app/PersonalVocab.vue';
 import testData from './testData';
 
 const localVue = createLocalVue();
 localVue.use(Vuex);
+localVue.use(BootstrapVue);
 
 describe('VocabPersonal', () => {
   let actions;


### PR DESCRIPTION
This PR fixes the jest test vue warning message: `[Vue warn]: Unknown custom element: <b-form-input> - did you register the component correctly? For recursive components, make sure to provide the "name" option.`
- Added bootstrapvue plugin as an import/plugin in `VocabGeneral` and `VocabPersonal` test specs