### PR TITLE
Make actions use async

### DIFF
--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -15,24 +15,24 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
   /* -------------------------------------------------------------------------- */
-  form_fetch: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
-  form_fetchPartial: (lang, form, cb) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`).then((r) => cb(r.data)),
+  form_fetch: (lang, form) => axios.get(`${BASE_URL}lemmatization/forms/${lang}/${encodeURIComponent(form)}/`),
+  form_fetchPartial: (lang, form) => axios.get(`${BASE_URL}lemmatization/partial_match_forms/${lang}/${encodeURIComponent(form)}/`),
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Lemma                            */
   /* -------------------------------------------------------------------------- */
-  lemma_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`).then((r) => cb(r.data)),
+  lemma_fetch: (id) => axios.get(`${BASE_URL}lemmatization/lemma/${id}/`),
 
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  lemmatizedText_cancel: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`).then((r) => cb(r.data)),
-  lemmatizedText_clone: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`).then((r) => cb(r.data)),
-  lemmatizedText_fetch: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`).then((r) => cb(r.data)),
-  lemmatizedText_fetchStatus: (id, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`).then((r) => cb(r.data)),
-  lemmatizedText_fetchTokens: (id, vocabList, personalVocabList, cb) => {
+  lemmatizedText_cancel: (id) => axios.post(`${BASE_URL}lemmatized_texts/${id}/cancel/`),
+  lemmatizedText_clone: (id) => axios.post(`${BASE_URL}lemmatized_texts/${id}/clone/`),
+  lemmatizedText_fetch: (id) => axios.get(`${BASE_URL}lemmatized_texts/${id}/detail/`),
+  lemmatizedText_fetchStatus: (id) => axios.get(`${BASE_URL}lemmatized_texts/${id}/status/`),
+  lemmatizedText_fetchTokens: (id, vocabList, personalVocabList) => {
     if (!vocabList && !personalVocabList) {
-      return axios.get(`${BASE_URL}lemmatized_texts/${id}/`).then((r) => cb(r.data));
+      return axios.get(`${BASE_URL}lemmatized_texts/${id}/`);
     }
     let qs = '';
     if (vocabList) {
@@ -41,12 +41,12 @@ export default {
     if (personalVocabList) {
       qs = `personalvocablist=${personalVocabList}`;
     }
-    return axios.get(`${BASE_URL}lemmatized_texts/${id}/?${qs}`).then((r) => cb(r.data));
+    return axios.get(`${BASE_URL}lemmatized_texts/${id}/?${qs}`);
   },
   lemmatizedText_fetchTokenHistory: (id, tokenIndex, cb) => axios.get(`${BASE_URL}lemmatized_texts/${id}/tokens/${tokenIndex}/history/`).then((r) => cb(r.data)),
-  lemmatizedText_list: (cb) => axios.get(`${BASE_URL}lemmatized_texts/`).then((r) => cb(r.data)),
-  lemmatizedText_retry: (id, cb) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`).then((r) => cb(r.data)),
-  lemmatizedText_updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null, cb) => {
+  lemmatizedText_list: () => axios.get(`${BASE_URL}lemmatized_texts/`),
+  lemmatizedText_retry: (id) => axios.post(`${BASE_URL}lemmatized_texts/${id}/retry/`),
+  lemmatizedText_updateToken: (id, tokenIndex, resolved, vocabList, lemmaId = null, glossIds = [], lemma = null) => {
     if (vocabList === null) {
       return axios.post(`${BASE_URL}lemmatized_texts/${id}/`, {
         tokenIndex,
@@ -54,7 +54,7 @@ export default {
         glossIds,
         lemma,
         resolved,
-      }).then((r) => cb(r.data));
+      });
     }
     return axios.post(`${BASE_URL}lemmatized_texts/${id}/?vocablist_id=${vocabList}`, {
       tokenIndex,
@@ -62,7 +62,7 @@ export default {
       glossIds,
       lemma,
       resolved,
-    }).then((r) => cb(r.data));
+    });
   },
 
   /* -------------------------------------------------------------------------- */
@@ -70,7 +70,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   bookmark_create: (textId) => axios.post(`${BASE_URL}bookmarks/`, { textId }),
   bookmark_delete: (bookmarkId) => axios.delete(`${BASE_URL}bookmarks/${bookmarkId}/`),
-  bookmark_list: (cb) => axios.get(`${BASE_URL}bookmarks/`).then((r) => cb(r.data)),
+  bookmark_list: () => axios.get(`${BASE_URL}bookmarks/`),
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
@@ -134,7 +134,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */
   /* -------------------------------------------------------------------------- */
-  supportedLangList_fetch: (cb) => axios.get(`${BASE_URL}supported_languages/`).then((r) => cb(r.data)),
+  supportedLangList_fetch: () => axios.get(`${BASE_URL}supported_languages/`),
 
   /* -------------------------------------------------------------------------- */
   /*         TODO: Delete these things, ensuring that they are not used.        */

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -9,8 +9,8 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  profile_fetch: (cb) => axios.get(`${BASE_URL}me/`).then((r) => cb(r.data)),
-  profile_updateLang: (lang, cb) => axios.post(`${BASE_URL}me/`, { lang }).then((r) => cb(r.data)),
+  profile_fetch: () => axios.get(`${BASE_URL}me/`),
+  profile_updateLang: (lang) => axios.post(`${BASE_URL}me/`, { lang }),
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
@@ -76,7 +76,7 @@ export default {
   /*                      vocab_list.PersonalVocabularyList                     */
   /* -------------------------------------------------------------------------- */
   personalVocabularyList_fetch: (lang) => axios.get(`${BASE_URL}personal_vocab_list/?lang=${lang}`),
-  personalVocabularyList_fetchLangList: (cb) => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`).then((r) => cb(r.data)),
+  personalVocabularyList_fetchLangList: () => axios.get(`${BASE_URL}personal_vocab_list/quick_add/`),
   personalVocabularyList_update: (textId, lemmaId, familiarity, headword, definition, entryId, lang) => {
     let data = {
       familiarity, headword, definition, lemmaId,
@@ -94,7 +94,7 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  personalVocabularyListEntry_create: (headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb) => {
+  personalVocabularyListEntry_create: (headword, definition, vocabularyListId, familiarity, lang, lemmaId) => {
     const payload = {
       headword,
       definition,
@@ -103,9 +103,9 @@ export default {
       lang,
       lemma_id: lemmaId,
     };
-    return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload).then((r) => cb(r.data));
+    return axios.post(`${BASE_URL}personal_vocab_list/quick_add/`, payload);
   },
-  personalVocabularyListEntry_delete: (id, cb) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }).then((r) => cb(r)),
+  personalVocabularyListEntry_delete: (id) => axios.delete(`${BASE_URL}personal_vocab_list/`, { data: { id } }),
 
   /* -------------------------------------------------------------------------- */
   /*                          vocab_list.VocabularyList                         */

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -45,10 +45,15 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                               hedera.Profile                               */
   /* -------------------------------------------------------------------------- */
-  [PROFILE_FETCH]: ({ commit }) => api.profile_fetch((data) => commit(PROFILE_FETCH, data.data)),
-  [PROFILE_SET_LANGUAGE_PREF]: ({ commit }, { lang }) => {
-    const cb = commit(PROFILE_SET_LANGUAGE_PREF, lang);
-    return api.profile_updateLang(lang, cb).catch(logoutOnError(commit));
+  [PROFILE_FETCH]: async ({ commit }) => {
+    // get `data` property of axios response, where response data is
+    const { data } = await api.profile_fetch();
+    // in the commit, still need to get data.data because that's how the api response wraps it
+    commit(PROFILE_FETCH, data.data);
+  },
+  [PROFILE_SET_LANGUAGE_PREF]: async ({ commit }, { lang }) => {
+    const { data } = await api.profile_updateLang(lang);
+    commit(PROFILE_SET_LANGUAGE_PREF, data.data.lang);
   },
 
   /* -------------------------------------------------------------------------- */
@@ -126,26 +131,28 @@ export default {
       .catch(logoutOnError(commit));
     commit(VOCAB_LIST_UPDATE, data.data.personalVocabList);
   },
-  [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: ({ commit }) => {
-    const cb = (data) => commit(PERSONAL_VOCAB_LIST_FETCH_LANG_LIST, data.data);
-    return api
-      .personalVocabularyList_fetchLangList(cb)
-      .catch(logoutOnError(commit));
+  [PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]: async ({ commit }) => {
+    const { data } = await api.personalVocabularyList_fetchLangList();
+    commit(PERSONAL_VOCAB_LIST_FETCH_LANG_LIST, data.data);
   },
 
   /* -------------------------------------------------------------------------- */
   /*                   vocab_list.PersonalVocabularyListEntry                   */
   /* -------------------------------------------------------------------------- */
-  [PERSONAL_VOCAB_ENTRY_CREATE]: ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
-    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_CREATE, data.data);
-    return api
-      .personalVocabularyListEntry_create(headword, definition, vocabularyListId, familiarity, lang, lemmaId, cb)
-      .catch(logoutOnError(commit));
+  [PERSONAL_VOCAB_ENTRY_CREATE]: async ({ commit }, { headword, definition, vocabularyListId, familiarity, lang, lemmaId }) => {
+    const { data } = await api.personalVocabularyListEntry_create(
+      headword,
+      definition,
+      vocabularyListId,
+      familiarity,
+      lang,
+      lemmaId,
+    );
+    commit(PERSONAL_VOCAB_ENTRY_CREATE, data.data);
   },
-  [PERSONAL_VOCAB_ENTRY_DELETE]: ({ commit }, { id }) => {
-    const cb = (data) => commit(PERSONAL_VOCAB_ENTRY_DELETE, data.data);
-    return api.personalVocabularyListEntry_delete(id, cb)
-      .catch(logoutOnError(commit));
+  [PERSONAL_VOCAB_ENTRY_DELETE]: async ({ commit }, { id }) => {
+    const { data } = await api.personalVocabularyListEntry_delete(id);
+    commit(PERSONAL_VOCAB_ENTRY_DELETE, data);
   },
   // eslint-disable-next-line max-len
   [PERSONAL_VOCAB_ENTRY_UPDATE]: async ({ commit, state }, { entryId, familiarity, headword, definition, lang = null, lemmaId }) => {

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -59,68 +59,78 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Form                             */
   /* -------------------------------------------------------------------------- */
-  [FORMS_FETCH]: ({ commit }, { lang, form }) => api.form_fetch(lang, form, (data) => commit(FORMS_FETCH, data)),
+  [FORMS_FETCH]: async ({ commit }, { lang, form }) => {
+    const response = await api.form_fetch(lang, form);
+    commit(FORMS_FETCH, response);
+  },
   // Note: might be slow to looks up partial matches
-  [FORMS_FETCH_PARTIAL]: ({ commit }, { lang, form }) => api.form_fetchPartial(lang, form, (data) => commit(FORMS_FETCH_PARTIAL, data)),
+  [FORMS_FETCH_PARTIAL]: async ({ commit }, { lang, form }) => {
+    const response = await api.form_fetchPartial(lang, form);
+    commit(FORMS_FETCH_PARTIAL, response);
+  },
 
   /* -------------------------------------------------------------------------- */
   /*                             lemmatization.Lemma                            */
   /* -------------------------------------------------------------------------- */
-  [LEMMA_FETCH]: ({ commit }, { id }) => api.lemma_fetch(id, (data) => commit(LEMMA_FETCH, data)),
+  [LEMMA_FETCH]: async ({ commit }, { id }) => {
+    const response = await api.lemma_fetch(id);
+    commit(LEMMA_FETCH, response);
+  },
 
   /* -------------------------------------------------------------------------- */
   /*                       lemmatized_text.LemmatizedText                       */
   /* -------------------------------------------------------------------------- */
-  [LEMMATIZED_TEXT_FETCH]: ({ commit }, { id }) => api
-    .lemmatizedText_fetch(id, (data) => commit(LEMMATIZED_TEXT_FETCH, data.data))
-    .catch(logoutOnError(commit)),
-  [LEMMATIZED_TEXT_FETCH_TOKENS]: ({ commit }, { id, vocabListId, personalVocabListId }) => {
-    commit(LEMMATIZED_TEXT_SET_ID, id);
-    const cb = (data) => commit(LEMMATIZED_TEXT_FETCH_TOKENS, data.data);
-    return api
-      .lemmatizedText_fetchTokens(id, vocabListId, personalVocabListId, cb)
-      .catch(logoutOnError(commit));
+  [LEMMATIZED_TEXT_FETCH]: async ({ commit }, { id }) => {
+    const { data } = await api.lemmatizedText_fetch(id);
+    commit(LEMMATIZED_TEXT_FETCH, data);
   },
-  [LEMMATIZED_TEXT_SELECT_TOKEN]: ({ commit, state }, { token }) => api.lemmatizedText_fetchTokenHistory(
-    state.textId,
-    token.tokenIndex,
-    (data) => commit(LEMMATIZED_TEXT_SELECT_TOKEN, { token, data }),
-  ),
-  [LEMMATIZED_TEXT_UPDATE_TOKEN]: ({ commit, state }, { id, tokenIndex, lemmaId, glossIds, resolved }) => {
+  [LEMMATIZED_TEXT_FETCH_TOKENS]: async ({ commit }, { id, vocabListId, personalVocabListId }) => {
+    commit(LEMMATIZED_TEXT_SET_ID, id);
+    const { data } = await api.lemmatizedText_fetchTokens(id, vocabListId, personalVocabListId);
+    commit(LEMMATIZED_TEXT_FETCH_TOKENS, data);
+  },
+  [LEMMATIZED_TEXT_SELECT_TOKEN]: async ({ commit, state }, { token }) => {
+    const response = await api.lemmatizedText_fetchTokenHistory(
+      state.textId,
+      token.tokenIndex,
+    );
+    commit(LEMMATIZED_TEXT_SELECT_TOKEN, { token, data: response });
+  },
+  [LEMMATIZED_TEXT_UPDATE_TOKEN]: async (
+    { commit, state },
+    { id, tokenIndex, lemmaId, glossIds, resolved },
+  ) => {
     // Fetch the most recent lemma data
-    api
-      .lemma_fetch(lemmaId, (data) => commit(LEMMA_FETCH, data))
-      .catch(logoutOnError(commit));
-
-    // Callback to commit the changes once the API call has completed
-    const mutate = (data) => commit(LEMMATIZED_TEXT_UPDATE_TOKEN, data.data);
-
+    const response = await api.lemma_fetch(lemmaId);
+    commit(LEMMA_FETCH, response);
     // Perform the API request to update the token data
-    return api
-      .lemmatizedText_updateToken(id, tokenIndex, resolved, state.selectedVocabList, lemmaId, glossIds, null, mutate)
-      .catch(logoutOnError(commit));
+    const { data } = await api.lemmatizedText_updateToken(
+      id,
+      tokenIndex,
+      resolved,
+      state.selectedVocabList,
+      lemmaId,
+      glossIds,
+      null,
+    );
+    commit(LEMMATIZED_TEXT_UPDATE_TOKEN, data);
   },
 
   /* -------------------------------------------------------------------------- */
   /*                   lemmatized_text.LemmatizedTextBookmark                   */
   /* -------------------------------------------------------------------------- */
-  [BOOKMARK_CREATE]: ({ dispatch, commit }, { textId }) => (
-    api
-      .bookmark_create(textId)
-      .then(() => dispatch(BOOKMARK_LIST))
-      .catch(logoutOnError(commit))
-  ),
-  [BOOKMARK_DELETE]: ({ dispatch, commit }, { bookmarkId }) => (
-    api
-      .bookmark_delete(bookmarkId)
-      .then(() => dispatch(BOOKMARK_LIST))
-      .catch(logoutOnError(commit))
-  ),
-  [BOOKMARK_LIST]: ({ commit }) => (
-    api
-      .bookmark_list((data) => commit(BOOKMARK_LIST, data.data))
-      .catch(logoutOnError(commit))
-  ),
+  [BOOKMARK_CREATE]: async ({ dispatch }, { textId }) => {
+    await api.bookmark_create(textId);
+    dispatch(BOOKMARK_LIST);
+  },
+  [BOOKMARK_DELETE]: async ({ dispatch }, { bookmarkId }) => {
+    await api.bookmark_delete(bookmarkId);
+    dispatch(BOOKMARK_LIST);
+  },
+  [BOOKMARK_LIST]: async ({ commit }) => {
+    const { data } = await api.bookmark_list();
+    commit(BOOKMARK_LIST, data);
+  },
 
   /* -------------------------------------------------------------------------- */
   /*                      vocab_list.PersonalVocabularyList                     */
@@ -261,8 +271,6 @@ export default {
     const updatedEntries = [...state.vocabList.entries];
     updatedEntries[localEntryIndex] = data;
 
-    console.log('updatedEntries:');
-    console.log(updatedEntries);
     commit(VOCAB_ENTRY_UPDATE_MANY, updatedEntries);
     return null;
   },
@@ -270,10 +278,10 @@ export default {
   /* -------------------------------------------------------------------------- */
   /*                            Not accessing a model                           */
   /* -------------------------------------------------------------------------- */
-  [SUPPORTED_LANG_LIST_FETCH]: ({ commit }) => (
-    api.supportedLangList_fetch((data) => commit(SUPPORTED_LANG_LIST_FETCH, data.data))
-      .catch(logoutOnError(commit))
-  ),
+  [SUPPORTED_LANG_LIST_FETCH]: async ({ commit }) => {
+    const { data } = await api.supportedLangList_fetch();
+    commit(SUPPORTED_LANG_LIST_FETCH, data);
+  },
 
   /* -------------------------------------------------------------------------- */
   /*         TODO: Delete these things, ensuring that they are not used.        */

--- a/static/src/js/app/vuex/tests/actions.spec.js
+++ b/static/src/js/app/vuex/tests/actions.spec.js
@@ -1,4 +1,6 @@
+import axios from 'axios';
 import {
+  PROFILE_FETCH,
   PERSONAL_VOCAB_ENTRY_CREATE,
   PERSONAL_VOCAB_ENTRY_DELETE,
   PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
@@ -6,54 +8,94 @@ import {
 } from '../../constants';
 import actions from '../actions';
 
-let url = '';
-let body = {};
+const BASE_URL = '/api/v1/';
 
-jest.mock('axios', () => ({
-  post: (_url, _body) => new Promise((resolve) => {
-    url = _url;
-    body = _body;
-    resolve(true);
-  }),
-  get: (_url) => new Promise((resolve) => {
-    url = _url;
-    resolve(true);
-  }),
-  delete: (_url, _body) => new Promise((resolve) => {
-    url = _url;
-    body = _body;
-    resolve(_body);
-  }),
-  defaults: { withCredentials: true },
-}));
+jest.mock('axios');
+
 describe('Actions', () => {
-  describe('PERSONAL_VOCAB_LIST_FETCH_LANG_LIST', () => {
-    it('successfully calls fetchPersonalVocabLangList action to update state', async () => {
+  /* This is a reference implementation for testing vuex actions, so it has
+  more comments than usual. The basic idea is to test that whatever API calls
+  the function uses get called with expected parameters, and that the resulting
+  call to the mutation gets called with its own expected parameters. The test
+  doesn't rely on a functioning api endpoint; instead jest is mocking axios
+  calls, and each test is using axios.<method>.mockResolvedValueOnce(response),
+  where `response` is an object that has the keys of an axios response that the
+  function expects. Note that the body of a response is in the `data` key of an
+  axios response, so most API calls will make use of that key. Reference the
+  axios response schema for other parts of the response that may be used.
+
+  Ideally tests should be grouped by data models, similar to the way that the
+  actions themselves are grouped, and each `describe()` should include some
+  shared objects for expected payloads and responses. Unfortunately
+  idiosyncracies in how the Django API is constructed make this impractical in
+  many cases, but it's something to shoot for. */
+  describe('hedera.Profile', () => {
+    const profile = {
+      data: { // axios data wrapper
+        data: { // api response data wrapper
+          displayName: 'mockUser',
+          email: 'mock@mock.mock',
+          lang: 'lat',
+          showNodeIds: 'never',
+        },
+      },
+    };
+
+    it(`${PROFILE_FETCH} handles successful api response`, async () => {
+      // mock response from API, retrieved via axios
+      axios.get.mockResolvedValueOnce(profile);
+
+      // mock the commit
       const commit = jest.fn();
-      // TODO: when passed in the response isnt returned from the commit in the expect block, check why
-      //   const response = {
-      //     data: [
-      //       {
-      //         lang: 'lat',
-      //         id: 1
-      //       },
-      //       {
-      //         lang: 'grc',
-      //         id: 36
-      //       }
-      //     ]
-      //   };
-      await actions[PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]({ commit });
-      expect(url).toBe('/api/v1/personal_vocab_list/quick_add/');
-    //   expect(commit).toHaveBeenCalledWith(
-    //     PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
-    //     undefined
-    //   );
+      await actions[PROFILE_FETCH]({ commit });
+
+      // expect the API to have been called with the appropriate URL
+      expect(axios.get).toHaveBeenCalledWith(`${BASE_URL}me/`);
+
+      // expect the correct mutation to have been called with the correct update data
+      expect(commit).toHaveBeenCalledWith(
+        PROFILE_FETCH,
+        profile.data.data,
+      );
+    });
+
+    it(`${PROFILE_SET_LANGUAGE_PREF} handles successful api response`, async () => {
+      axios.post.mockResolvedValueOnce(profile);
+      const payload = { lang: 'lat' };
+      const commit = jest.fn();
+      await actions[PROFILE_SET_LANGUAGE_PREF]({ commit }, payload);
+      expect(axios.post).toHaveBeenCalledWith(`${BASE_URL}me/`, payload);
+      expect(commit).toHaveBeenCalledWith(
+        PROFILE_SET_LANGUAGE_PREF,
+        profile.data.data.lang,
+      );
     });
   });
-  describe('PERSONAL_VOCAB_ENTRY_CREATE', () => {
-    it('successfully calls createPersonalVocabEntry action to update state', async () => {
+  describe('vocab_list.PersonalVocabularyList', () => {
+    const apiResponse = {
+      data: {
+        data: [
+          { lang: 'lat', id: 1 },
+        ],
+      },
+    };
+
+    it(`${PERSONAL_VOCAB_LIST_FETCH_LANG_LIST} handles successful api response`, async () => {
+      axios.get.mockResolvedValueOnce(apiResponse);
       const commit = jest.fn();
+      await actions[PERSONAL_VOCAB_LIST_FETCH_LANG_LIST]({ commit });
+      expect(axios.get).toHaveBeenCalledWith(`${BASE_URL}personal_vocab_list/quick_add/`);
+      expect(commit).toHaveBeenCalledWith(
+        PERSONAL_VOCAB_LIST_FETCH_LANG_LIST,
+        apiResponse.data.data,
+      );
+    });
+  });
+
+  describe('vocab_list.PersonalVocabularyEntry', () => {
+    it(`${PERSONAL_VOCAB_ENTRY_CREATE} works with well-formed payload`, async () => {
+      const commit = jest.fn();
+      // payload sent to action
       const payload = {
         headword: 'ergo',
         definition: 'sum',
@@ -62,38 +104,51 @@ describe('Actions', () => {
         lang: 'lat',
         vocabularyListId: 1,
       };
-      //   const response = { data: { created: true } };
-      await actions[PERSONAL_VOCAB_ENTRY_CREATE]({ commit }, payload);
-      // expect(commit).toHaveBeenCalledWith(PERSONAL_VOCAB_ENTRY_CREATE, response)
-      expect(url).toBe('/api/v1/personal_vocab_list/quick_add/');
-      expect(body).toEqual({
-        headword: 'ergo',
-        definition: 'sum',
-        vocabulary_list_id: 1,
-        familiarity: 1,
-        lemma_id: 1,
-        lang: 'lat',
-      });
-    });
-  });
-
-  describe('PROFILE_SET_LANGUAGE_PREF', () => {
-    it('successfully calls PROFILE_SET_LANGUAGE_PREF', async () => {
-      const commit = jest.fn();
-      const payload = {
-        lang: 'lat',
+      // payload sent to api function
+      const { lemmaId, vocabularyListId, ...apiPayload } = payload;
+      apiPayload.lemma_id = lemmaId;
+      apiPayload.vocabulary_list_id = vocabularyListId;
+      // mocked API response
+      const apiResponse = {
+        data: {
+          data: {
+            created: true,
+            data: {},
+          },
+        },
       };
-      await actions[PROFILE_SET_LANGUAGE_PREF]({ commit }, payload);
-      expect(commit).toHaveBeenCalledWith(PROFILE_SET_LANGUAGE_PREF, 'lat');
+      axios.post.mockResolvedValueOnce(apiResponse);
+      await actions[PERSONAL_VOCAB_ENTRY_CREATE]({ commit }, payload);
+      expect(axios.post).toHaveBeenCalledWith(
+        `${BASE_URL}personal_vocab_list/quick_add/`,
+        apiPayload,
+      );
+      expect(commit).toHaveBeenCalledWith(
+        PERSONAL_VOCAB_ENTRY_CREATE,
+        apiResponse.data.data,
+      );
     });
-  });
-  describe('PERSONAL_VOCAB_ENTRY_DELETE', () => {
-    it('successfully calls PERSONAL_VOCAB_ENTRY_DELETE', async () => {
+
+    it(`${PERSONAL_VOCAB_ENTRY_DELETE} works with well-formed payload`, async () => {
+      const vocabEntryId = 1;
+      const payload = { id: vocabEntryId };
       const commit = jest.fn();
-      const payload = { id: 1 };
+      const apiResponse = {
+        data: {
+          data: true,
+          id: vocabEntryId,
+        },
+      };
+      axios.delete.mockResolvedValueOnce(apiResponse);
       await actions[PERSONAL_VOCAB_ENTRY_DELETE]({ commit }, payload);
-      expect(commit).toHaveBeenCalledWith(PERSONAL_VOCAB_ENTRY_DELETE, payload);
-      expect(body.data).toEqual(payload);
+      expect(axios.delete).toHaveBeenCalledWith(
+        `${BASE_URL}personal_vocab_list/`,
+        { data: { id: payload.id } },
+      );
+      expect(commit).toHaveBeenCalledWith(
+        PERSONAL_VOCAB_ENTRY_DELETE,
+        apiResponse.data,
+      );
     });
   });
 });


### PR DESCRIPTION
This PR makes any action that makes an api call into an `async` function that `await`s the response from the api, rather than relying on passing callbacks through to the api calls.

It also revamps the actions test suite to ensure that the API is being called with the expected parameters, mock out axios calls to the api to simulate a returned data object, and ensure that the mutation in the action is also called with the expected parameters. The first test in the suite has extra documentation to use as a reference implementation for adding additional action tests beyond the 5 that are currently implemented.