### PR TITLE
updated python version from 3.7 to 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.7
+  python: python3.10
 repos:
   - repo: https://github.com/pycqa/isort
     rev: 5.9.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7 AS prod
+FROM python:3.10 AS prod
 
 # Upgrade pip
 RUN pip install --upgrade pip


### PR DESCRIPTION
This PR updates the `DockerFile` and `pre-commit-config.yaml` Python version from 3.7 to 3.10([Django 3.2 Supported](https://docs.djangoproject.com/en/4.1/releases/3.2/#python-compatibility)). 

Resolves #492 