### PR TITLE
Fix bug where quick add would not load in dashboard and navbar

### DIFF
--- a/hedera/templates/_account_bar.html
+++ b/hedera/templates/_account_bar.html
@@ -10,7 +10,8 @@
                 <i class="fa fa-user" aria-hidden="true" title="User"></i><span class="sr-only">User:</span> {% user_display request.user %}
                 </button>
                 <ul class="dropdown-content">
-                    <li id="quick-add"></li>
+                    {% comment %} removed for now - buggy - modal window should not be a child of dropdown-content {% endcomment %}
+                    {% comment %} <li id="quick-add"></li> {% endcomment %}
                     <li class="nav-item">
                         <a href="{% url 'account_settings' %}"><i class="fa fa-cog" aria-hidden="true"></i> {% trans "Settings" %}</a>
                     </li>

--- a/static/src/js/app/Dashboard.vue
+++ b/static/src/js/app/Dashboard.vue
@@ -1,12 +1,17 @@
 <template>
   <div class="dashboard">
-    <QuickAddButton/>
-    <BookmarkList/>
+    <QuickAddButton />
+    <BookmarkList />
   </div>
 </template>
 <script>
   import QuickAddButton from './components/quick-add-button';
-  import { PROFILE_FETCH, SUPPORTED_LANG_LIST_FETCH } from './constants';
+  import {
+    PROFILE_FETCH,
+    SUPPORTED_LANG_LIST_FETCH,
+    PERSONAL_VOCAB_LIST_FETCH,
+    VOCAB_LIST_SET_TYPE,
+  } from './constants';
   import BookmarkList from './modules/BookmarkList.vue';
 
   export default {
@@ -14,6 +19,9 @@
     async created() {
       await this.$store.dispatch(PROFILE_FETCH);
       await this.$store.dispatch(SUPPORTED_LANG_LIST_FETCH);
+      // Dashboard quick add will default to personal vocab list
+      this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang: this.lang });
+      this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'personal' });
     },
   };
 </script>

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -99,7 +99,8 @@ export default {
       headword,
       definition,
       familiarity,
-      vocabulary_list_id: vocabularyListId,
+      // Django doesnt pick up key:value pairs with undefined values
+      vocabulary_list_id: vocabularyListId || null,
       lang,
       lemma_id: lemmaId,
     };

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -325,7 +325,8 @@
       },
       isPersonal() {
         // Return a boolean for whether or not the current vocab list is a personal vocab list.
-        return this.vocabListType === 'personal';
+        // Added secondary parameter in case vocabListType is null(Ex: Dashboard or nav bar)
+        return this.vocabListType === 'personal' || !this.vocabListType;
       },
       vocabularyListId() {
         // Get vocab list ID from state. Should be set from Vocab component on

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -344,7 +344,6 @@
       },
       isPersonal() {
         // Return a boolean for whether or not the current vocab list is a personal vocab list.
-        // Added secondary parameter in case vocabListType is null(Ex: Dashboard or nav bar)
         return this.vocabListType === 'personal';
       },
       vocabularyListId() {

--- a/static/src/js/app/constants.js
+++ b/static/src/js/app/constants.js
@@ -43,7 +43,7 @@ export const VOCAB_LIST_SET_TYPE = 'vocabularyList_setType';
 export const VOCAB_LIST_UPDATE = 'vocabularyList_update';
 
 // vocab_list.VocabularyListEntry
-export const VOCAB_ENTRY_CREATE = 'vocabularyListEntry_delete';
+export const VOCAB_ENTRY_CREATE = 'vocabularyListEntry_create';
 export const VOCAB_ENTRY_DELETE = 'vocabularyListEntry_delete';
 export const VOCAB_ENTRY_UPDATE = 'vocabularyListEntry_update';
 export const VOCAB_ENTRY_UPDATE_MANY = 'vocabularyListEntry_updateMany';

--- a/static/src/js/app/index.js
+++ b/static/src/js/app/index.js
@@ -15,7 +15,7 @@ import Learner from './Learner.vue';
 import PersonalVocab from './PersonalVocab.vue';
 import Texts from './Texts.vue';
 import Dashboard from './Dashboard.vue';
-import QuickAddButton from './components/quick-add-button';
+// import QuickAddButton from './components/quick-add-button';
 
 Vue.config.productionTip = false;
 
@@ -84,7 +84,8 @@ export default () => {
   load('vocab-app', PersonalVocab, null, vocabAppProps);
   load('texts-app', Texts, null, () => {});
   load('dashboard-app', Dashboard, null, () => {});
-  load('quick-add', QuickAddButton, null, () => ({
-    personalVocab: true,
-  }));
+  // Removed for now - buggy - modal window should not be a child of dropdown-content
+  // load('quick-add', QuickAddButton, null, () => ({
+  //   personalVocab: true,
+  // }));
 };

--- a/static/src/js/app/index.js
+++ b/static/src/js/app/index.js
@@ -84,5 +84,7 @@ export default () => {
   load('vocab-app', PersonalVocab, null, vocabAppProps);
   load('texts-app', Texts, null, () => {});
   load('dashboard-app', Dashboard, null, () => {});
-  load('quick-add', QuickAddButton, null, () => {});
+  load('quick-add', QuickAddButton, null, () => ({
+    personalVocab: true,
+  }));
 };


### PR DESCRIPTION
This PR fixes a bug where quick add would not load in dashboard and navbar due to undefined variable `this.vocabListType` and failing submit for personal vocab list from quick add modal
 - Added secondary condition to default to personal vocab  if `this.vocabListType` is null
 - Fix constant name/action for `vocabularyListEntry_create`
 - Added `isPersonal` variables to dashboard and navbar to default to personal vocab list in the quick add modal
 - Fix quick add for personal vocab list