### PR TITLE
fix underscore

### DIFF
--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -49,11 +49,19 @@ class BaseService(object):
 
     def check_text(self, text):
         """
-        Returns text or False of text
+        Returns TRUE or False based on the
 
         This method must be overridden.
         """
         raise NotImplementedError("Must provide check_text implementation on a per service basis.")
+
+    def apply_text_rule(self, unique_text, data):
+        """
+        Returns text or dict based on rules applied to modify the text
+
+        This method must be overridden.
+        """
+        raise NotImplementedError("Must provide apply_text_rule implementation on a per service basis.")
 
 
 class HttpService(BaseService):

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -49,9 +49,8 @@ class BaseService(object):
 
     def check_text(self, text):
         """
-        Returns TRUE or False based on the language rules
+        Returns TRUE or False based on the language unique rules
         (ex: Latin uses underscores to join lemmas together via re_tokenize_clitics() function)
-
         This method must be overridden.
         """
         raise NotImplementedError("Must provide check_text implementation on a per service basis.")

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -47,6 +47,14 @@ class BaseService(object):
         """
         return word
 
+    def check_text(self, text):
+        """
+        Returns text or False of text
+
+        This method must be overridden.
+        """
+        raise NotImplementedError("Must provide check_text implementation on a per service basis.")
+
 
 class HttpService(BaseService):
     ENDPOINT = ""

--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -49,7 +49,8 @@ class BaseService(object):
 
     def check_text(self, text):
         """
-        Returns TRUE or False based on the
+        Returns TRUE or False based on the language rules
+        (ex: Latin uses underscores to join lemmas together via re_tokenize_clitics() function)
 
         This method must be overridden.
         """

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -96,6 +96,14 @@ class LatinService(BaseService):
             word = strip_macrons(word)
         return word
 
+    def check_text(self, text):
+        """
+        For Latin, checking if edited text needs to be formatted based on underscore via latin_periphrastic_normalizer
+        """
+        if "_" in text:
+            return text
+        return False
+
 
 class LatinTokenizer(Tokenizer):
     """Latin tokenizer.

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -104,6 +104,14 @@ class LatinService(BaseService):
             return text
         return False
 
+    def apply_text_rule(self, unique_text, data):
+        if unique_text and unique_text is not data:
+            return {
+                "data": unique_text + data,
+                "unique_text": False
+            }
+        return data
+
 
 class LatinTokenizer(Tokenizer):
     """Latin tokenizer.

--- a/lemmatization/services/latin.py
+++ b/lemmatization/services/latin.py
@@ -101,10 +101,14 @@ class LatinService(BaseService):
         For Latin, checking if edited text needs to be formatted based on underscore via latin_periphrastic_normalizer
         """
         if "_" in text:
-            return text
+            return True
         return False
 
     def apply_text_rule(self, unique_text, data):
+        """
+        joins text with underscore together
+        TODO: create factory function to apply multiple rules to text
+        """
         if unique_text and unique_text is not data:
             return {
                 "data": unique_text + data,

--- a/lemmatized_text/models.py
+++ b/lemmatized_text/models.py
@@ -244,14 +244,12 @@ class LemmatizedText(models.Model):
             lang=self.lang
         )
         edit_parser.feed(cleaned_edits)
-
         # Trimming junk tokens that get appended to the end of the list
         for token in reversed(edit_parser.lemmatized_text_data):
             if token["word"] != "":
                 break
             edit_parser.lemmatized_text_data.remove(token)
         self.data = edit_parser.lemmatized_text_data
-
         strip_parser = TagStripper()
         strip_parser.feed(cleaned_edits)
         self.original_text = strip_parser.get_data()

--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -53,11 +53,11 @@ class EditedTextHtmlParser(HTMLParser):
         self.current_data = ""
 
     def handle_data(self, data):
-        # used to join text that been modified by the service(e.g latin underscores)
-        # we might need to move this out into the language service in the future to make it more general
-        if self.unique_text and self.unique_text is not data:
-            data = self.unique_text + data
-            self.unique_text = False
+        # used to modify data by the service(e.g latin underscores)
+        formated_text_data = self.service.apply_text_rule(self.unique_text, data)
+        if type(formated_text_data) is dict:
+            data = formated_text_data["data"]
+            self.unique_text = formated_text_data["unique_text"]
         if ("follower" in self.current_attrs):
             self.current_data = data
         else:

--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -53,6 +53,8 @@ class EditedTextHtmlParser(HTMLParser):
         self.current_data = ""
 
     def handle_data(self, data):
+        # used to join text that been modified by the service(e.g latin underscores)
+        # we might need to move this out into the language service in the future to make it more general
         if self.unique_text and self.unique_text is not data:
             data = self.unique_text + data
             self.unique_text = False

--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -1,7 +1,9 @@
 import json
+import re
 from html.parser import HTMLParser
 from io import StringIO
 
+from hedera.supported_languages import SUPPORTED_LANGUAGES
 from lemmatization.lemmatizer import Lemmatizer
 
 
@@ -14,7 +16,9 @@ class EditedTextHtmlParser(HTMLParser):
         self.lemmatized_text_data = []
         self.token_lemma_dict = token_lemma_dict
         self.lemmatizer = Lemmatizer(lang)
+        self.service = SUPPORTED_LANGUAGES[lang].service
         self.initial = ""
+        self.unique_text = False
         return super().__init__()
 
     def handle_starttag(self, tag, attrs):
@@ -49,6 +53,9 @@ class EditedTextHtmlParser(HTMLParser):
         self.current_data = ""
 
     def handle_data(self, data):
+        if self.unique_text and self.unique_text is not data:
+            data = self.unique_text + data
+            self.unique_text = False
         if ("follower" in self.current_attrs):
             self.current_data = data
         else:
@@ -62,7 +69,9 @@ class EditedTextHtmlParser(HTMLParser):
                 else:
                     self.current_data = data
             except KeyError:
-                self.lemmatize_chunk(data)
+                self.unique_text = self.service.check_text(data)
+                if not self.unique_text:
+                    self.lemmatize_chunk(data)
 
     def separate_true_followers(self, follower):
         """
@@ -101,22 +110,35 @@ class EditedTextHtmlParser(HTMLParser):
         Takes an unrecognized chunk of text.
         Sends 'chunk' to be lemmatized, then extends the data with the returned content.
         Checks if chunk does not contain return and newline "\r\n" - only add tokens if it the chunk is not a return/newline
+        In case there is an newline at the beginning of the text("initial"), the newline char will be added to the previous text "following" key:value pair
         **Fixes problem with empty tokens**
+        **Fixes problem with latin underscores**
         Returns None
         """
         self.current_data = None
-        # lemmatized_text_data_length = len(self.lemmatized_text_data)
         new_data = self.lemmatizer.lemmatize(chunk)
-        if "\r\n" not in chunk:
+        # regex checks if '\r\n' is the only char used in the chunk
+        contains_only_newline = bool(re.match(r"^[\r\n]+$", chunk))
+        if not contains_only_newline:
+            self.process_initial_data(new_data)
             self.lemmatized_text_data.extend(new_data)
-        elif "\r\n" in chunk and len(self.lemmatized_text_data):
-            following = self.lemmatized_text_data[-1]["following"]
+        if contains_only_newline and len(self.lemmatized_text_data):
             token_lemma_dict_keys = list(self.token_lemma_dict.keys())
             prev_lemma_id = self.lemmatized_text_data[-1]["lemma_id"]
+            following = self.lemmatized_text_data[-1]["following"]
             #Note: Added check if we have reached the end of the data array because theres a bug where new lines are added after each edit
-            if prev_lemma_id not in self.token_lemma_dict[token_lemma_dict_keys[-1]]:
+            if len(token_lemma_dict_keys) and prev_lemma_id not in self.token_lemma_dict[token_lemma_dict_keys[-1]]:
                 self.lemmatized_text_data[-1]["following"] = f"{following}{chunk}"
+            else:
+                self.process_initial_data(new_data)
+                self.lemmatized_text_data.extend(new_data)
         #TODO EDGE CASE: Newlines/breaks that may happen at the very beginning of the text
+
+    def process_initial_data(self, new_data):
+        # if statement will add newlines to "following" to previous text in lemmatized_text_data
+        if new_data[0]["initial"] and len(self.lemmatized_text_data):
+            following = self.lemmatized_text_data[-1]["following"]
+            self.lemmatized_text_data[-1]["following"] = f"{following}{new_data[0]['initial']}"
 
 
 class TagStripper(HTMLParser):

--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -71,7 +71,8 @@ class EditedTextHtmlParser(HTMLParser):
                 else:
                     self.current_data = data
             except KeyError:
-                self.unique_text = self.service.check_text(data)
+                if self.service.check_text(data):
+                    self.unique_text = data
                 if not self.unique_text:
                     self.lemmatize_chunk(data)
 

--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -54,10 +54,10 @@ class EditedTextHtmlParser(HTMLParser):
 
     def handle_data(self, data):
         # used to modify data by the service(e.g latin underscores)
-        formated_text_data = self.service.apply_text_rule(self.unique_text, data)
-        if type(formated_text_data) is dict:
-            data = formated_text_data["data"]
-            self.unique_text = formated_text_data["unique_text"]
+        formatted_text_data = self.service.apply_text_rule(self.unique_text, data)
+        if type(formatted_text_data) is dict:
+            data = formatted_text_data["data"]
+            self.unique_text = formatted_text_data["unique_text"]
         if ("follower" in self.current_attrs):
             self.current_data = data
         else:

--- a/lemmatized_text/test_data.py
+++ b/lemmatized_text/test_data.py
@@ -141,4 +141,27 @@ test_lemmatized_text = [
     },
 ]
 
+test_lemmatized_no_underscore_text = [
+    {
+        "word": "contristatus",
+        "glossed": "glossed-automatic",
+        "initial": "",
+        "lemma_id": 13339,
+        "resolved": "no-ambiguity",
+        "following": " ",
+        "gloss_ids": [70218],
+        "word_normalized": "contristatus",
+    },
+    {
+        "word": "est",
+        "glossed": "glossed-automatic",
+        "initial": "",
+        "lemma_id": 1225,
+        "resolved": "no-ambiguity",
+        "following": " ",
+        "gloss_ids": [86130, 81965],
+        "word_normalized": "est",
+    },
+]
+
 test_original_text = """Arma virumque canō, Trōiae quī prīmus ab ōrīs\r\nĪtaliam, fātō profugus, Lāvīniaque vēnit"""

--- a/lemmatized_text/tests.py
+++ b/lemmatized_text/tests.py
@@ -195,7 +195,6 @@ class LemmatizedTextTests(TestCase):
         # insert edited text at the end of a closing </span> element
         index_to_insert_edit = test_text_html.find("</span>")
         test_edited_text_html = test_text_html[:index_to_insert_edit] + "\n\rcontristatus_est" + test_text_html[index_to_insert_edit:]
-        print(test_edited_text_html)
         example_text.handle_edited_data("Test title", test_edited_text_html)
         self.assertEqual("contristatus est" in example_text.token_lemma_dict(), True)
 

--- a/lemmatized_text/tests.py
+++ b/lemmatized_text/tests.py
@@ -4,7 +4,11 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 
 from .models import LemmatizedText, transform_data_to_html
-from .test_data import test_lemmatized_text, test_original_text
+from .test_data import (
+    test_lemmatized_no_underscore_text,
+    test_lemmatized_text,
+    test_original_text
+)
 
 
 def create_user(username, email, password):
@@ -161,6 +165,39 @@ class LemmatizedTextTests(TestCase):
         test_edited_text_html = transform_data_to_html(test_lemmatized_text)
         example_text.handle_edited_data("Test title", test_edited_text_html)
         self.assertEqual(example_text.token_count(), len(test_lemmatized_text))
+
+    def test_handle_edited_data_underscore(self):
+        """
+        Example expected behavior
+            text without underscore - token_lemma_dict={'contristatus': [13339], 'est': [1225]}
+            edited text with underscore - token_lemma_dict={'': [13339, 1225], 'contristatus est': [13339]}
+        """
+        example_text = LemmatizedText.objects.create(
+            title="Test underscore edit",
+            lang="lat",
+            original_text="contristatus est",
+            created_by=self.created_user1,
+            data=test_lemmatized_no_underscore_text
+        )
+        example_text.handle_edited_data("Test title", "contristatus_est")
+        self.assertEqual("contristatus est" in example_text.token_lemma_dict(), True)
+
+    def test_handle_edited_data_underscore_long_text(self):
+
+        example_text = LemmatizedText.objects.create(
+            title="Test add text with underscore",
+            lang="lat",
+            original_text=test_original_text,
+            created_by=self.created_user1,
+            data=test_lemmatized_text
+        )
+        test_text_html = transform_data_to_html(test_lemmatized_text)
+        # insert edited text at the end of a closing </span> element
+        index_to_insert_edit = test_text_html.find("</span>")
+        test_edited_text_html = test_text_html[:index_to_insert_edit] + "\n\rcontristatus_est" + test_text_html[index_to_insert_edit:]
+        print(test_edited_text_html)
+        example_text.handle_edited_data("Test title", test_edited_text_html)
+        self.assertEqual("contristatus est" in example_text.token_lemma_dict(), True)
 
 
 class LemmatizedTextViewsTests(TestCase):


### PR DESCRIPTION
This PR is to fix issue #500 where latin text edited with underscores will not be picked up by the editor.
- added `check_text` and `apply_text_rule ` to latin service to be used in the `parsers.py` to determine underscores in a text
- added test for edits with underscore