### PR TITLE
fix failing editor when unedited text are submitted

### DIFF
--- a/lemmatized_text/parsers.py
+++ b/lemmatized_text/parsers.py
@@ -139,7 +139,7 @@ class EditedTextHtmlParser(HTMLParser):
 
     def process_initial_data(self, new_data):
         # if statement will add newlines to "following" to previous text in lemmatized_text_data
-        if new_data[0]["initial"] and len(self.lemmatized_text_data):
+        if len(new_data) and new_data[0]["initial"] and len(self.lemmatized_text_data):
             following = self.lemmatized_text_data[-1]["following"]
             self.lemmatized_text_data[-1]["following"] = f"{following}{new_data[0]['initial']}"
 


### PR DESCRIPTION
This PR fixes the failing edits when unedited text is submitted to the edit endpoint.
- Added a check for length of the new_data due to error `list index out of range` when accessing array elements in `parsers.py`