### PR TITLE
fix missing icons due to fontawesome kit expire

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ If you've run a lot of containers and you'd like to clean them up so that your `
 docker ps --filter status=exited --filter name=hedera_django_run -q | xargs docker rm
 ```
 
+##### Font Awesome Kit
+Notes: base.html is using a js file provided by Font Awesome Kit `https://kit.fontawesome.com/2db98e34e3.js`. This means that icons like the familarity and edit buttons will stop working if the link expires. Think is created from [Font Awesome Kit Setup](https://fontawesome.com/docs/web/setup/use-kit). We could download the js file and run it locally as well, but will hold off for now.
+
 ### Without Docker
 
 You'll need Redis running.  To get it going locally on the Mac, simply run:

--- a/hedera/templates/site_base.html
+++ b/hedera/templates/site_base.html
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block extra_head_base %}
-  <script src="https://kit.fontawesome.com/b59f827277.js" crossorigin="anonymous"></script>
+  <script src="https://kit.fontawesome.com/2db98e34e3.js" crossorigin="anonymous"></script>
   {% block extra_head %}{% endblock %}
 {% endblock %}
 


### PR DESCRIPTION
This PR fixes the missing icons in the personal vocabulary page.
- Updated the fontawesome kit link
- Added under the `gotchas` section of the readme noting the setup for fontawesome kit link

Note: we can download the `js` file into the repo as well, and not rely on the link. Will hold off until further review.