### PR TITLE
Updated github actions to use python 3.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-            python-version: 3.10
+            python-version: '3.10'
 
         - uses: actions/setup-node@v2
           with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v2
           with:
-            python-version: 3.7
+            python-version: 3.10
 
         - uses: actions/setup-node@v2
           with:


### PR DESCRIPTION
This PR updates Github Actions [setup-python](https://github.com/actions/setup-python) to use python 3.10, which matches the deployed version in the `Dockerfile.`