### PR TITLE
Fix spaces being added after edited words

### DIFF
--- a/lemmatization/services/base.py
+++ b/lemmatization/services/base.py
@@ -7,7 +7,7 @@ def pairwise(iterable):
     return zip(a, a)
 
 
-def eveniter(iterable, last=" "):
+def eveniter(iterable, last=""):
     """ Generates an even number of values. """
     even = True
     for value in iterable:


### PR DESCRIPTION
When a word is edited, and that word has punctuation following it, a space is added between the word and the punctuation. Testing revealed that this is happening in the lemmatization process, and specifically that this function is adding the space. This PR changes the function to use a default empty string, rather than a string containing a space.

I believe that the lemmatization process expects to work on a sequence of tokens like [word, following, word, following, word], so in a case where the sequence ends with a word with no following, something must be added so that the lemmatization can deal with words and following characters. This just changes the function that normalizes the data to meet that assumption to do so while not changing the data.