### PR TITLE
Add sentry

### DIFF
--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -14,15 +14,15 @@ except ValueError:
     IS_LTI = False
 
 # Initialize Sentry for Error Tracking (see also: https://docs.sentry.io/)
-if not IS_LTI:
-    sentry_sdk.init(
-        dsn=os.environ.get("SENTRY_DSN"),
-        debug=os.environ.get("SENTRY_DEBUG") == "1",
-        environment=os.environ.get("SENTRY_ENVIRONMENT"),
-        integrations=[DjangoIntegration(), RqIntegration()],
-        # Enables tracing for sentry "Events V2"
-        # https://github.com/getsentry/zeus/blob/764df526f47d9387a03b5afcdf3ec0758ae38ac2/zeus/config.py#L380
-    )
+
+sentry_sdk.init(
+    dsn=os.environ.get("SENTRY_DSN"),
+    debug=os.environ.get("SENTRY_DEBUG") == "1",
+    environment=os.environ.get("SENTRY_ENVIRONMENT"),
+    integrations=[DjangoIntegration(), RqIntegration()],
+    # Enables tracing for sentry "Events V2"
+    # https://github.com/getsentry/zeus/blob/764df526f47d9387a03b5afcdf3ec0758ae38ac2/zeus/config.py#L380
+)
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/hedera/settings.py
+++ b/hedera/settings.py
@@ -20,6 +20,7 @@ sentry_sdk.init(
     debug=os.environ.get("SENTRY_DEBUG") == "1",
     environment=os.environ.get("SENTRY_ENVIRONMENT"),
     integrations=[DjangoIntegration(), RqIntegration()],
+    traces_sample_rate=1.0,
     # Enables tracing for sentry "Events V2"
     # https://github.com/getsentry/zeus/blob/764df526f47d9387a03b5afcdf3ec0758ae38ac2/zeus/config.py#L380
 )

--- a/hedera/urls.py
+++ b/hedera/urls.py
@@ -15,6 +15,11 @@ from lti.views import LtiInitializerView
 from . import api, views
 
 
+def trigger_error(request):
+    division_by_zero = 1 / 0
+    return division_by_zero
+
+
 urlpatterns = [
     path("robots.txt", TemplateView.as_view(template_name="robots.txt", content_type="text/plain")),
 
@@ -60,6 +65,8 @@ urlpatterns = [
 
     path("cms/", include(wagtailadmin_urls)),
     re_path(r"", include(wagtail_urls)),
+    # test url to make sure sentry is working
+    path("sentry-debug/", trigger_error),
 
 ] + static(
     settings.STATIC_URL, document_root=settings.STATIC_URL

--- a/web-entrypoint.sh
+++ b/web-entrypoint.sh
@@ -22,6 +22,7 @@ exec gunicorn hedera.wsgi:application \
     --env REDIS_URL=$REDIS_URL \
     --env RQ_ASYNC=$RQ_ASYNC \
     --env SENTRY_DSN="$SENTRY_DSN" \
+    --env SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
     --env SENTRY_ENVIRONMENT=$SENTRY_ENVIRONMENT \
     --env DJANGO_DEBUG=$DJANGO_DEBUG \
     --env SESSION_COOKIE_SECURE=${SESSION_COOKIE_SECURE:-1} \

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
+const SentryWebpackPlugin = require('@sentry/webpack-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 const hotReload = process.env.HOT_RELOAD === '1';
@@ -63,6 +64,17 @@ const plugins = [
     patterns: [
       { from: './static/src/images/**/*', to: path.resolve('./static/dist/images/[name].[ext]'), toType: 'template' },
     ],
+  }),
+  new SentryWebpackPlugin({
+    ignoreFile: '.sentrycliignore',
+    ignore: ['node_modules', 'webpack.config.js'],
+    configFile: 'sentry.properties',
+    dryRun: true,
+    release: 'v1.0.0',
+    project: 'hedera',
+    org: 'harvard-university-academic-te',
+    include: './static/dist',
+    authToken: process.env.SENTRY_AUTH_TOKEN,
   }),
 ];
 


### PR DESCRIPTION
This PR adds sentry to frontend and backend.
- atg-ops-ecs has been updated to pull in sentry-auth-token
- added an endpoint to trigger via sentry-debug
- added sentry-auth-token into the ssm param store