### PR TITLE
Update breadcrumbs/title in django template

### DIFF
--- a/hedera/templates/lemmatized_text/learner_text.html
+++ b/hedera/templates/lemmatized_text/learner_text.html
@@ -11,8 +11,8 @@
 
 {% block body %}
   <nav>
-    <a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a>
-    &laquo;
+    <a href="{% if request.META.HTTP_REFERER %}{{ request.META.HTTP_REFERER }}{% else %}{% url 'lemmatized_texts_list' %}{% endif %}">Lemmatized Texts</a>
+    &raquo;
     <h1 class="font-weight-bold d-inline font-size-1">{{ text.title }}</h1>
     {% if PDF_HANDOUT_ENABLED %}
     <div style="float: right;">

--- a/hedera/templates/lemmatized_text/learner_text.html
+++ b/hedera/templates/lemmatized_text/learner_text.html
@@ -11,9 +11,9 @@
 
 {% block body %}
   <nav>
-    {% comment %} <a href="/lemmatized_text/">Lemmatized Texts</a>
+    <a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a>
     &laquo;
-    <b>{{ text.title }}</b> {% endcomment %}
+    <b>{{ text.title }}</b>
     {% if PDF_HANDOUT_ENABLED %}
     <div style="float: right;">
       <a href="{% url 'lemmatized_texts_handout' text.secret_id %}" target="_blank">

--- a/hedera/templates/lemmatized_text/learner_text.html
+++ b/hedera/templates/lemmatized_text/learner_text.html
@@ -13,7 +13,7 @@
   <nav>
     <a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a>
     &laquo;
-    <b>{{ text.title }}</b>
+    <h1 class="font-weight-bold d-inline font-size-1">{{ text.title }}</h1>
     {% if PDF_HANDOUT_ENABLED %}
     <div style="float: right;">
       <a href="{% url 'lemmatized_texts_handout' text.secret_id %}" target="_blank">

--- a/hedera/templates/lemmatized_text/learner_text.html
+++ b/hedera/templates/lemmatized_text/learner_text.html
@@ -11,9 +11,9 @@
 
 {% block body %}
   <nav>
-    <a href="/lemmatized_text/">Lemmatized Texts</a>
-    &raquo;
-    <b>{{ text.title }}</b>
+    {% comment %} <a href="/lemmatized_text/">Lemmatized Texts</a>
+    &laquo;
+    <b>{{ text.title }}</b> {% endcomment %}
     {% if PDF_HANDOUT_ENABLED %}
     <div style="float: right;">
       <a href="{% url 'lemmatized_texts_handout' text.secret_id %}" target="_blank">

--- a/hedera/templates/lemmatized_text/text.html
+++ b/hedera/templates/lemmatized_text/text.html
@@ -10,6 +10,6 @@
 {% block navbar-toggler %}{% endblock %}
 
 {% block body %}
-  <nav><a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a> &laquo; <h1 class="font-weight-bold d-inline font-size-1">{{ text.title }}</h1></nav>
+  <nav><a href="{% if request.META.HTTP_REFERER %}{{ request.META.HTTP_REFERER }}{% else %}{% url 'lemmatized_texts_list' %}{% endif %}">Lemmatized Texts</a> &raquo; <h1 class="font-weight-bold d-inline font-size-1">{{ text.title }}</h1></nav>
   <div id="app" text-id="{{ text.pk }}"></div>
 {% endblock %}

--- a/hedera/templates/lemmatized_text/text.html
+++ b/hedera/templates/lemmatized_text/text.html
@@ -10,6 +10,6 @@
 {% block navbar-toggler %}{% endblock %}
 
 {% block body %}
-  <nav><a href="/lemmatized_text/">Lemmatized Texts</a> &raquo; <b>{{ text.title }}</b></nav>
+  {% comment %} <nav><a href="/lemmatized_text/">Lemmatized Texts</a> &laquo; <b>{{ text.title }}</b></nav> {% endcomment %}
   <div id="app" text-id="{{ text.pk }}"></div>
 {% endblock %}

--- a/hedera/templates/lemmatized_text/text.html
+++ b/hedera/templates/lemmatized_text/text.html
@@ -10,6 +10,6 @@
 {% block navbar-toggler %}{% endblock %}
 
 {% block body %}
-  {% comment %} <nav><a href="/lemmatized_text/">Lemmatized Texts</a> &laquo; <b>{{ text.title }}</b></nav> {% endcomment %}
+  <nav><a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a> &laquo; <b>{{ text.title }}</b></nav>
   <div id="app" text-id="{{ text.pk }}"></div>
 {% endblock %}

--- a/hedera/templates/lemmatized_text/text.html
+++ b/hedera/templates/lemmatized_text/text.html
@@ -10,6 +10,6 @@
 {% block navbar-toggler %}{% endblock %}
 
 {% block body %}
-  <nav><a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a> &laquo; <b>{{ text.title }}</b></nav>
+  <nav><a href={{ request.META.HTTP_REFERER }}>Lemmatized Texts</a> &laquo; <h1 class="font-weight-bold d-inline font-size-1">{{ text.title }}</h1></nav>
   <div id="app" text-id="{{ text.pk }}"></div>
 {% endblock %}

--- a/static/src/scss/_text.scss
+++ b/static/src/scss/_text.scss
@@ -20,3 +20,7 @@ div.lemmatized-text.text-lang-zho {
 .no-lemma {
   color: hsl(0, 44%, 60%);
 }
+
+.font-size-1{
+  font-size: 1rem;
+}


### PR DESCRIPTION
Fix breadcrumbs in django templates to navigate to previous page instead of lemmatized text and changed the `<b/>` to `<h1/>`
Note:  I have left the a tag name as `Lemmatized Texts`. Feel free to comment on how we should change the naming convention to either `back` or `previous`