### PR TITLE
fixing undefined lang when loading vue dashboard

### DIFF
--- a/static/src/js/app/Dashboard.vue
+++ b/static/src/js/app/Dashboard.vue
@@ -20,7 +20,14 @@
       await this.$store.dispatch(PROFILE_FETCH);
       await this.$store.dispatch(SUPPORTED_LANG_LIST_FETCH);
       // Dashboard quick add will default to personal vocab list
-      this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang: this.lang });
+      let lang = this.lang || null;
+      // look up lang if null
+      if (!this.lang) {
+        lang = (this.$store.state.me.lang
+          || this.$store.state.personalVocabLangList)
+          && this.$store.state.personalVocabLangList[0].lang;
+      }
+      this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, { lang });
       this.$store.dispatch(VOCAB_LIST_SET_TYPE, { vocabListType: 'personal' });
     },
   };


### PR DESCRIPTION
This PR fixes an error where lang is undefined when `Dashboard.vue` is loaded.