### PR TITLE
Fixing personal vocab list issues

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/hedera/api.py
+++ b/hedera/api.py
@@ -449,11 +449,12 @@ class PersonalVocabularyListAPI(APIView):
         if pk is not None:
             entry = get_object_or_404(PersonalVocabularyListEntry, pk=pk)
             # Update based on data payload
+            if not data["lemma"]:
+                return JsonResponseNotFound({"error": "Missing or blank lemmaId."})
             lemma_id = data.get("lemmaId", None)
             if lemma_id:
                 data["lemma"] = lemma = get_object_or_404(Lemma, pk=lemma_id)
-                # data["lemma"] = lemma if get_object_or_404(Lemma, pk=lemma_id) == data["lemma"] else get_object_or_404(Lemma, lemma=data["lemma"])
-            for field in ["familiarity", "headword", "definition", "lemma"]:
+            for field in ["familiarity", "headword", "definition"]:
                 data_field = data.get(field, None)
                 if data_field is not None:
                     setattr(entry, field, data_field)

--- a/hedera/api.py
+++ b/hedera/api.py
@@ -452,6 +452,7 @@ class PersonalVocabularyListAPI(APIView):
             lemma_id = data.get("lemmaId", None)
             if lemma_id:
                 data["lemma"] = lemma = get_object_or_404(Lemma, pk=lemma_id)
+                # data["lemma"] = lemma if get_object_or_404(Lemma, pk=lemma_id) == data["lemma"] else get_object_or_404(Lemma, lemma=data["lemma"])
             for field in ["familiarity", "headword", "definition", "lemma"]:
                 data_field = data.get(field, None)
                 if data_field is not None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12557,6 +12557,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/levn/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13784,6 +13797,19 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/optionator/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -18490,18 +18516,6 @@
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
       "dev": true
-    },
-    "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -24085,13 +24099,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -24939,7 +24955,8 @@
     "bootstrap": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "requires": {}
     },
     "bootstrap-vue": {
       "version": "2.23.1",
@@ -31107,6 +31124,18 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      },
+      "dependencies": {
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
       }
     },
     "lines-and-columns": {
@@ -32097,6 +32126,18 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      },
+      "dependencies": {
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
       }
     },
     "os-browserify": {
@@ -32422,7 +32463,8 @@
     "portal-vue": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
-      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==",
+      "requires": {}
     },
     "portfinder": {
       "version": "1.0.32",
@@ -35828,16 +35870,6 @@
       "integrity": "sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==",
       "dev": true
     },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "dev": true,
-      "peer": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -36623,7 +36655,8 @@
     "vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "requires": {}
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -14,11 +14,8 @@
             props.column.field == 'lemma' &&
             editingFields.entryId == props.row.id
           ">
-            <!-- <b-form-input list="lemma-list-id" class="form-control" v-model="props.row.lemma" v-on:keyup.enter="onEnter"
-              @keyup="fetchPartialLemmas(props.row.lemma)"></b-form-input> -->
             <b-form-input list="lemma-list-id" class="form-control" v-model="editingFields.lemma"
-              @input="props.row.lemma = editingFields.lemma" v-on:keyup.enter="onEnter"
-              @keyup="fetchPartialLemmas(props.row.lemma)"></b-form-input>
+              v-on:keyup.enter="onEnter" @keyup="fetchPartialLemmas(editingFields.lemma)"></b-form-input>
             <datalist id="lemma-list-id">
               <option v-for="lemma in partialMatchLemmas" :key="lemma.pk" :value="lemma.lemma">
                 {{lemma.glosses.map((glossObj) => glossObj.gloss).join(", ")}}
@@ -29,16 +26,14 @@
             props.column.field == 'headword' &&
             editingFields.entryId == props.row.id
           ">
-            <input class="form-control" v-model="props.row.headword" v-on:keyup.enter="onEnter"
-              @keyup="changeCell(props.column.field, props.row)" />
+            <input class="form-control" v-model="editingFields.headword" v-on:keyup.enter="onEnter" />
           </span>
 
           <div class="d-flex" v-if="
             props.column.field == 'definition' &&
             editingFields.entryId == props.row.id
           ">
-            <input class="form-control" v-model="props.row.definition" v-on:keyup.enter="onEnter"
-              @keyup="changeCell(props.column.field, props.row)" />
+            <input class="form-control" v-model="editingFields.definition" v-on:keyup.enter="onEnter" />
           </div>
           <div v-if="props.column.field == 'edit'" class="d-flex edit-width">
             <button id="td-edit-button" class="btn btn-sm edit-entry" href
@@ -178,6 +173,8 @@
           headword,
           definition,
           lang: this.lang,
+          lemmaId: entry.lemma_id,
+          lemma: entry.lemma,
         });
         await this.$store.dispatch(PERSONAL_VOCAB_LIST_FETCH, {
           lang: this.lang,
@@ -226,12 +223,21 @@
         // switched order of two code blocks to await
         if (this.partialMatchLemmas.length) {
           const found = this.partialMatchLemmas.find((el) => el.lemma === lemma);
-          if (found) {
-            this.editingFields.lemmaId = found.pk;
-          }
+          // if (found) {
+          //   this.editingFields.lemmaId = found.pk;
+          // }
+          this.editingFields.lemmaId = found ? found.pk : null;
         }
       },
       async onSave() {
+        if (!this.editingFields.lemma || !this.editingFields.lemma.trim()) {
+          this.makeToast("Lemma field cannot be blank.", 400);
+          return;
+        }
+        if (!this.editingFields.lemmaId) {
+          this.makeToast("No valid lemma selected.", 400);
+          return;
+        }
         this.saving = true;
         const {
           entryId,
@@ -269,6 +275,13 @@
             `Successfully Updated Vocabulary ${headword}`,
             'Success!',
           );
+        }
+        const row = this.vocabEntries.find((r) => r.id === entryId);
+        if (row) {
+          row.headword = headword;
+          row.definition = definition;
+          row.lemma = lemma;
+          row.familiarity = familiarity;
         }
         this.saving = false;
         this.resetEdit();

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -54,7 +54,11 @@
             </div>
           </div>
           <div v-if="props.column.field == 'familiarity'" class="d-flex">
-            <FamiliarityRating :value="props.row.familiarity" @input="(rating) => onRatingChange(rating, props.row)" />
+            <FamiliarityRating v-if="editingFields.entryId === props.row.id"
+              :value="familiarityInputs[props.row.id] !== undefined ? familiarityInputs[props.row.id] : props.row.familiarity"
+              @input="(rating) => onInlineFamiliarityChange(rating, props.row)" />
+            <FamiliarityRating v-else :value="props.row.familiarity"
+              @input="(rating) => onRatingChange(rating, props.row)" />
           </div>
 
           <div v-else-if="editingFields.entryId != props.row.id">
@@ -144,6 +148,7 @@
           lemma: null,
         },
         vocabListType: null,
+        familiarityInputs: {},
       };
     },
     created() {
@@ -154,6 +159,10 @@
       document.removeEventListener('keydown', this.onKeyDown);
     },
     methods: {
+      async onInlineFamiliarityChange(rating, row) {
+        this.$set(this.familiarityInputs, row.id, rating);
+        this.editingFields.familiarity = rating;
+      },
       makeToast(statusText, statusCode) {
         this.$bvToast.toast(statusText, {
           title: statusCode,
@@ -223,9 +232,6 @@
         // switched order of two code blocks to await
         if (this.partialMatchLemmas.length) {
           const found = this.partialMatchLemmas.find((el) => el.lemma === lemma);
-          // if (found) {
-          //   this.editingFields.lemmaId = found.pk;
-          // }
           this.editingFields.lemmaId = found ? found.pk : null;
         }
       },

--- a/static/src/js/app/PersonalVocab.vue
+++ b/static/src/js/app/PersonalVocab.vue
@@ -7,111 +7,59 @@
       <DownloadVocab :glosses="glosses" :with-familiarity="true" />
     </div>
     <div v-if="vocabEntries">
-      <vue-good-table
-        :columns="columns"
-        :rows="vocabEntries"
-        :pagination-options="paginationOptions"
-        :search-options="searchOptions"
-      >
+      <vue-good-table :columns="columns" :rows="vocabEntries" :pagination-options="paginationOptions"
+        :search-options="searchOptions">
         <template slot="table-row" slot-scope="props">
-          <span
-            v-if="
-              props.column.field == 'lemma' &&
-              editingFields.entryId == props.row.id
-            "
-          >
-            <b-form-input
-              list="lemma-list-id"
-              class="form-control"
-              v-model="props.row.lemma"
-              v-on:keyup.enter="onEnter"
-              @keyup="fetchPartialLemmas(props.row.lemma)"
-            ></b-form-input>
+          <span v-if="
+            props.column.field == 'lemma' &&
+            editingFields.entryId == props.row.id
+          ">
+            <!-- <b-form-input list="lemma-list-id" class="form-control" v-model="props.row.lemma" v-on:keyup.enter="onEnter"
+              @keyup="fetchPartialLemmas(props.row.lemma)"></b-form-input> -->
+            <b-form-input list="lemma-list-id" class="form-control" v-model="editingFields.lemma"
+              @input="props.row.lemma = editingFields.lemma" v-on:keyup.enter="onEnter"
+              @keyup="fetchPartialLemmas(props.row.lemma)"></b-form-input>
             <datalist id="lemma-list-id">
-              <option
-                v-for="lemma in partialMatchLemmas"
-                :key="lemma.pk"
-                :value="lemma.lemma"
-              >
-                {{ lemma.glosses.map((glossObj) => glossObj.gloss).join(", ") }}
+              <option v-for="lemma in partialMatchLemmas" :key="lemma.pk" :value="lemma.lemma">
+                {{lemma.glosses.map((glossObj) => glossObj.gloss).join(", ")}}
               </option>
             </datalist>
           </span>
-          <span
-            v-if="
-              props.column.field == 'headword' &&
-              editingFields.entryId == props.row.id
-            "
-          >
-            <input
-              class="form-control"
-              v-model="props.row.headword"
-              v-on:keyup.enter="onEnter"
-              @keyup="changeCell(props.column.field, props.row)"
-            />
+          <span v-if="
+            props.column.field == 'headword' &&
+            editingFields.entryId == props.row.id
+          ">
+            <input class="form-control" v-model="props.row.headword" v-on:keyup.enter="onEnter"
+              @keyup="changeCell(props.column.field, props.row)" />
           </span>
 
-          <div
-            class="d-flex"
-            v-if="
-              props.column.field == 'definition' &&
-              editingFields.entryId == props.row.id
-            "
-          >
-            <input
-              class="form-control"
-              v-model="props.row.definition"
-              v-on:keyup.enter="onEnter"
-              @keyup="changeCell(props.column.field, props.row)"
-            />
+          <div class="d-flex" v-if="
+            props.column.field == 'definition' &&
+            editingFields.entryId == props.row.id
+          ">
+            <input class="form-control" v-model="props.row.definition" v-on:keyup.enter="onEnter"
+              @keyup="changeCell(props.column.field, props.row)" />
           </div>
           <div v-if="props.column.field == 'edit'" class="d-flex edit-width">
-            <button
-              id="td-edit-button"
-              class="btn btn-sm edit-entry"
-              href
-              @click.prevent="onEdit(props.row.id, props.row)"
-              v-if="editingFields.entryId != props.row.id"
-            >
-              <i
-                class="fa fa-fw fa-pen-fancy pen-icon-size"
-                aria-hidden="true"
-                title="Edit Entry"
-              />
+            <button id="td-edit-button" class="btn btn-sm edit-entry" href
+              @click.prevent="onEdit(props.row.id, props.row)" v-if="editingFields.entryId != props.row.id">
+              <i class="fa fa-fw fa-pen-fancy pen-icon-size" aria-hidden="true" title="Edit Entry" />
             </button>
             <div class="d-flex" v-if="editingFields.entryId == props.row.id">
-              <button
-                id="td-delete-button"
-                type="button"
-                aria-label="delete"
-                @click="deleteVocab(props.row.id)"
-                style="padding-top: 0"
-              >
+              <button id="td-delete-button" type="button" aria-label="delete" @click="deleteVocab(props.row.id)"
+                style="padding-top: 0">
                 <i class="fa fa-trash" aria-hidden="true" />
               </button>
-              <button
-                id="td-save-button"
-                class="btn btn-md"
-                href
-                @click.prevent="onSave"
-                v-if="saving === false"
-              >
+              <button id="td-save-button" class="btn btn-md" href @click.prevent="onSave" v-if="saving === false">
                 <i class="fas fa-save" aria-hidden="true" title="Submit" />
               </button>
-              <div
-                class="spinner-border text-success ml-2"
-                role="status"
-                v-if="saving === true"
-              >
+              <div class="spinner-border text-success ml-2" role="status" v-if="saving === true">
                 <span class="sr-only">Loading...</span>
               </div>
             </div>
           </div>
           <div v-if="props.column.field == 'familiarity'" class="d-flex">
-            <FamiliarityRating
-              :value="props.row.familiarity"
-              @input="(rating) => onRatingChange(rating, props.row)"
-            />
+            <FamiliarityRating :value="props.row.familiarity" @input="(rating) => onRatingChange(rating, props.row)" />
           </div>
 
           <div v-else-if="editingFields.entryId != props.row.id">
@@ -198,6 +146,7 @@
           entryId: null,
           familiarity: null,
           lemmaId: null,
+          lemma: null,
         },
         vocabListType: null,
       };
@@ -244,13 +193,14 @@
         }
       },
       onEdit(entryId, row) {
-        const { headword, definition, lemma_id: lemmaId } = row;
+        const { headword, definition, lemma_id: lemmaId, lemma } = row;
         this.editingFields = {
           entryId,
           headword,
           definition,
           lang: this.lang,
           lemmaId,
+          lemma,
         };
         if (this.isPersonal) {
           const { familiarity } = row;
@@ -268,16 +218,18 @@
         }
       },
       async fetchPartialLemmas(lemma) {
+        await this.$store.dispatch(LEMMAS_FETCH_PARTIAL, {
+          lemma,
+          lang: this.lang,
+        });
+
+        // switched order of two code blocks to await
         if (this.partialMatchLemmas.length) {
           const found = this.partialMatchLemmas.find((el) => el.lemma === lemma);
           if (found) {
             this.editingFields.lemmaId = found.pk;
           }
         }
-        await this.$store.dispatch(LEMMAS_FETCH_PARTIAL, {
-          lemma,
-          lang: this.lang,
-        });
       },
       async onSave() {
         this.saving = true;
@@ -287,6 +239,7 @@
           definition,
           familiarity,
           lemmaId,
+          lemma
         } = this.editingFields;
         let response = null;
         if (this.isPersonal) {
@@ -297,6 +250,7 @@
             definition,
             lang: this.lang,
             lemmaId,
+            lemma
           });
         } else {
           response = await this.$store.dispatch(VOCAB_ENTRY_UPDATE, {
@@ -309,7 +263,8 @@
         if (response) {
           const { statusText, status } = response;
           this.makeToast(statusText, `Error - ${status}`);
-        } else {
+        }
+        else {
           this.makeToast(
             `Successfully Updated Vocabulary ${headword}`,
             'Success!',
@@ -354,7 +309,7 @@
 
         if (this.isPersonal || this.vocabList.canEdit) {
           // Add edit column only if user can edit this vocab list
-          theColumns.push({ label: 'Edit', field: 'edit' });
+          theColumns.push({ label: 'Edit', field: 'edit', sortable: false });
         }
 
         return theColumns;
@@ -406,43 +361,46 @@
 </script>
 
 <style lang="scss">
-@import "../../scss/config";
+  @import "../../scss/config";
 
-// mobile view - TODO may need to update later
-@media only screen and (min-device-width: 360px) and (max-device-width: 812px) and (orientation: portrait) {
-  #td-no-padding-left-right {
-    padding-right: 0;
-    padding-left: 0;
+  // mobile view - TODO may need to update later
+  @media only screen and (min-device-width: 360px) and (max-device-width: 812px) and (orientation: portrait) {
+    #td-no-padding-left-right {
+      padding-right: 0;
+      padding-left: 0;
+    }
+
+    #td-no-padding-left {
+      padding-left: 0;
+    }
+
+    #td-familiarity-rating {
+      padding-right: 0;
+      padding-left: 0;
+    }
   }
 
-  #td-no-padding-left {
-    padding-left: 0;
+  // other views
+  @media only screen and (min-device-width: 813px) {
+    #td-familiarity-rating {
+      display: flex;
+      flex-direction: row;
+    }
   }
 
-  #td-familiarity-rating {
-    padding-right: 0;
-    padding-left: 0;
+  .pen-icon-size {
+    width: 40px;
+    height: 38px;
   }
-}
 
-// other views
-@media only screen and (min-device-width: 813px) {
-  #td-familiarity-rating {
-    display: flex;
-    flex-direction: row;
+  .edit-width {
+    width: 83px;
+    height: 2rem;
+    align-items: center;
+    justify-content: center;
   }
-}
-.pen-icon-size {
-  width: 40px;
-  height: 38px;
-}
-.edit-width {
-  width: 83px;
-  height: 2rem;
-  align-items: center;
-  justify-content: center;
-}
-.vgt-responsive {
-  overflow-x: visible;
-}
+
+  .vgt-responsive {
+    overflow-x: visible;
+  }
 </style>

--- a/static/src/js/app/api.js
+++ b/static/src/js/app/api.js
@@ -110,6 +110,7 @@ export default {
   personalVocabularyList_update: (
     textId,
     lemmaId,
+    lemma,
     familiarity,
     headword,
     definition,
@@ -121,6 +122,7 @@ export default {
       headword,
       definition,
       lemmaId,
+      lemma
     };
     if (lang !== null && entryId !== null) {
       return axios

--- a/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
+++ b/static/src/js/app/components/quick-add-button/QuickAddVocabForm.vue
@@ -2,72 +2,28 @@
   <div class="form-group">
     <p>Tab between fields and submit with the enter key. Hit escape to exit this window.</p>
     <form id="addvocab-form" v-on:submit.prevent>
-      <label v-if="isPersonal" for="FormControlSelect"
-        >Select Language of Your Vocabulary List</label
-      >
-      <select
-        v-if="isPersonal"
-        v-model="vocabularyListItem"
-        class="form-control mb-2"
-        id="FormControlSelect"
-        aria-label="language List"
-        ref="select"
-        required
-      >
-        <option
-          v-for="langItem in personalVocabLangList"
-          :key="langItem.id"
-          :value="langItem"
-        >
+      <label v-if="isPersonal" for="FormControlSelect">Select Language of Your Vocabulary List</label>
+      <select v-if="isPersonal" v-model="vocabularyListItem" class="form-control mb-2" id="FormControlSelect"
+        aria-label="language List" ref="select" required>
+        <option v-for="langItem in personalVocabLangList" :key="langItem.id" :value="langItem">
           {{ formatLang(langItem.lang) }}
         </option>
       </select>
       <div class="d-flex">
-        <input
-          id="quick-add-form-headword-entry"
-          class="form-control mt-2"
-          type="text"
-          placeholder="headword"
-          aria-label="headword"
-          v-model="headword"
-          v-on:input="getHeadword"
-          ref="headword"
-          required
-        />
-        <input
-          class="form-control ml-2 mt-2"
-          type="text"
-          placeholder="definition"
-          aria-label="definition"
-          v-model="definition"
-          required
-        />
+        <input id="quick-add-form-headword-entry" class="form-control mt-2" type="text" placeholder="headword"
+          aria-label="headword" v-model="headword" v-on:input="getHeadword" ref="headword" required />
+        <input class="form-control ml-2 mt-2" type="text" placeholder="definition" aria-label="definition"
+          v-model="definition" required />
         <div v-if="isPersonal" class="flex-column ml-2">
           <label class="mb-0" for="FamiliarityRating">Familiarity</label>
-          <FamiliarityRating
-            id="FamiliarityRating"
-            :style="{}"
-            customClass="d-flex"
-            :value="familiarityRating"
-            @input="(rating) => onRatingChange(rating)"
-            aria-label="familiarity"
-          />
+          <FamiliarityRating id="FamiliarityRating" :style="{}" customClass="d-flex" :value="familiarityRating"
+            @input="(rating) => onRatingChange(rating)" aria-label="familiarity" />
         </div>
       </div>
       <div class="lemma-options-container" v-if="lemmaOptions.length">
         <label for="lemma-select">Linked definition</label>
-        <div
-          id="lemma-options-inputs"
-          v-for="lemma in lemmaOptions"
-          :key="lemma.pk"
-        >
-          <input
-            type="radio"
-            v-model="lemmaId"
-            @change="onSelect"
-            :value="lemma.pk"
-            :id="`lemma-option-${lemma.pk}`"
-          />
+        <div id="lemma-options-inputs" v-for="lemma in lemmaOptions" :key="lemma.pk">
+          <input type="radio" v-model="lemmaId" @change="onSelect" :value="lemma.pk" :id="`lemma-option-${lemma.pk}`" />
           <label :for="`lemma-option-${lemma.pk}`">
             <span class="lemma-label" aria-label="headword">{{
               lemma.label.replace(/[0-9]/g, "")
@@ -79,22 +35,12 @@
           </label>
         </div>
       </div>
-      <button
-        type="submit"
-        :disabled="submitting"
-        class="btn btn-primary mt-3"
-        aria-label="Submit"
-        @click="handleSubmit"
-        @keyup.enter="handleSubmit"
-      >
+      <button type="submit" :disabled="submitting" class="btn btn-primary mt-3" aria-label="Submit"
+        @click="handleSubmit" @keyup.enter="handleSubmit">
         Submit
       </button>
     </form>
-    <div
-      class="alert custom-alert-success"
-      role="alert"
-      v-show="showSuccesAlert"
-    >
+    <div class="alert custom-alert-success" role="alert" v-show="showSuccesAlert">
       Successfully added Vocabulary Word to
       {{ this.isPersonal ? "Personal" : "" }} Vocabulary List!
     </div>
@@ -185,6 +131,10 @@
         this.showSuccesAlert = false;
         this.submitting = true;
 
+        const selectedLemma = this.lemmaOptions.find((l) => l.pk === this.lemmaId);
+        if (selectedLemma) {
+          this.headword = selectedLemma.label.replace(/[0-9]/g, '');
+        }
         const { headword, definition, vocabularyListItem } = this;
 
         // If headword and definition are empty, don't do anything on submit
@@ -293,7 +243,7 @@
         try {
           this.lemmaOptions = this.$store.state.forms[this.headword].lemmas;
         } catch (error) {
-        ("This is fine actually? It'll keep trying to access state until it succeeds."); // eslint-disable-line
+          ("This is fine actually? It'll keep trying to access state until it succeeds."); // eslint-disable-line
         }
         // sets first lemma option as the default in select options
         if (this.lemmaOptions.length) {
@@ -320,7 +270,7 @@
         this.definition = lemmaObj.glosses.length
           ? lemmaObj.glosses[0].gloss
           : '';
-        this.headword = lemmaObj.lemma;
+        // this.headword = lemmaObj.lemma;
       },
     },
     computed: {
@@ -363,14 +313,14 @@
 </script>
 
 <style lang="scss">
-.custom-alert-success {
-  color: #155724;
-  background-color: #d4edda;
-  border-color: #c3e6cb;
-}
+  .custom-alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+  }
 
-.lemma-options-container {
-  padding-top: 10px;
-  font-weight: bold;
-}
+  .lemma-options-container {
+    padding-top: 10px;
+    font-weight: bold;
+  }
 </style>

--- a/static/src/js/app/constants.js
+++ b/static/src/js/app/constants.js
@@ -35,7 +35,7 @@ export const PERSONAL_VOCAB_LIST_FETCH_LANG_LIST = 'personalVocabularyList_fetch
 // vocab_list.PersonalVocabularyListEntry
 export const PERSONAL_VOCAB_ENTRY_CREATE = 'personalVocabularyListEntry_create';
 export const PERSONAL_VOCAB_ENTRY_DELETE = 'personalVocabularyListEntry_delete';
-export const PERSONAL_VOCAB_ENTRY_UPDATE = 'personalVocabularyListEntry_update';
+export const PERSONAL_VOCAB_ENTRY_UPDATE = 'personalVocabularyListEntry_update'; // this is misleading, actually runs personalVocabularyList_update
 export const PERSONAL_VOCAB_ENTRY_UPDATE_MANY = 'personalVocabularyListEntry_updateMany';
 
 // vocab_list.VocabularyList

--- a/static/src/js/app/vuex/actions.js
+++ b/static/src/js/app/vuex/actions.js
@@ -198,12 +198,13 @@ export default {
   // eslint-disable-next-line max-len
   [PERSONAL_VOCAB_ENTRY_UPDATE]: async (
     { commit, state },
-    { entryId, familiarity, headword, definition, lang = null, lemmaId },
+    { entryId, familiarity, headword, definition, lang = null, lemmaId, lemma },
   ) => {
     // eslint-disable-next-line max-len
     const { response, data } = await api.personalVocabularyList_update(
       state.text.id,
       lemmaId,
+      lemma,
       familiarity,
       headword,
       definition,


### PR DESCRIPTION
Issues 502 and 538 addressed, as well as the table row jumping when trying to edit with a sort enabled. Also, headwords are added in full via quick add now. Added an extra "lemma" field to editingFields to attach the editing to that state instead of the props itself.

Main changes are in PersonalVocab.vue and QuickAdd.vue. Code check has not been working for most commits - "Missing download info for actions/cache@v2"