### PR TITLE
update actions/cache@v2 to v4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
         - name: Cache Python dependencies
           id: cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.cache/pip
             key: ${{ runner.os }}-pip-${{ hashFiles('**/**/requirements/dev.txt' ) }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
               ${{ runner.os }}-pip-
 
         - name: Cache node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -94,7 +94,7 @@ jobs:
 
         - name: Setup Cache
           id: cache
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.cache/pip
             key: ${{ runner.os }}-pip-${{ hashFiles('**/**/requirements/dev.txt' ) }}
@@ -124,7 +124,7 @@ jobs:
             node-version: '14'
 
         - name: Cache node modules
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: ~/.npm
             key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
This PR is to fix the github actions error for `actions/cache@v2` by updating to`v4`

Error message thats shows up in the github actions
```bash
Error: Missing download info for actions/cache@v2
```